### PR TITLE
fix(auth): 웹 환경 카카오 로그인 리다이렉트 URL 수정

### DIFF
--- a/app/api/auth/kakao/callback.tsx
+++ b/app/api/auth/kakao/callback.tsx
@@ -1,0 +1,35 @@
+/**
+ * app/api/auth/kakao/callback.tsx
+ * 백엔드 OAuth 콜백 처리 (임시 해결책)
+ * 
+ * ⚠️ 주의: 백엔드가 /api/auth/kakao/callback으로 리다이렉트하고 있어서
+ * 프론트엔드에서 이 경로를 처리할 수 있도록 추가했습니다.
+ * 
+ * 백엔드가 프론트엔드의 redirect_uri를 사용하도록 수정되면 이 파일은 제거해야 합니다.
+ */
+
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useEffect } from 'react';
+
+export default function ApiAuthKakaoCallback() {
+  const { token, isNewUser } = useLocalSearchParams<{ token?: string; isNewUser?: string }>();
+  const router = useRouter();
+
+  useEffect(() => {
+    // 토큰이 있으면 프론트엔드 콜백 라우트로 리다이렉트
+    if (token) {
+      const params = new URLSearchParams({ token });
+      if (isNewUser) {
+        params.append('isNewUser', isNewUser);
+      }
+      router.replace(`/auth/callback?${params.toString()}`);
+    } else {
+      // 토큰이 없으면 로그인 페이지로
+      router.replace('/(auth)/login');
+    }
+  }, [token, isNewUser, router]);
+
+  // 리다이렉트 중 표시할 내용 (빈 화면)
+  return null;
+}
+

--- a/commons/constants/routes.ts
+++ b/commons/constants/routes.ts
@@ -19,6 +19,7 @@ export const ROUTES = {
   // 인증
   AUTH_LOGIN: '/(auth)/login',
   AUTH_SIGNUP: '/(auth)/signup',
+  AUTH_CALLBACK: '/auth/callback', // OAuth 콜백 (웹 전용) - Expo Router에서 (auth) 그룹은 URL에 포함되지 않음
 } as const;
 
 export type RouteKey = keyof typeof ROUTES;

--- a/components/login/hooks/useKakaoLogin.ts
+++ b/components/login/hooks/useKakaoLogin.ts
@@ -3,7 +3,7 @@
  * 카카오 OAuth 로그인 처리만 담당
  */
 
-import { API_ENDPOINTS } from '@/commons/constants';
+import { API_ENDPOINTS, ROUTES } from '@/commons/constants';
 import { buildApiUrl } from '@/utils';
 import Constants from 'expo-constants';
 import * as Linking from 'expo-linking';
@@ -36,8 +36,10 @@ export function useKakaoLogin() {
       const baseLoginUrl = buildApiUrl(apiBaseUrl, API_ENDPOINTS.AUTH.KAKAO);
       
       // 플랫폼별 redirect_uri 설정
+      // ⚠️ 중요: 웹 환경에서는 프론트엔드 라우트 경로를 사용해야 함
+      // 백엔드는 이 redirect_uri로 리다이렉트하므로, 프론트엔드 라우트와 일치해야 함
       const redirectUri = Platform.OS === 'web'
-        ? `${window.location.origin}/auth/callback`  // 웹: 현재 도메인의 /auth/callback
+        ? `${window.location.origin}${ROUTES.AUTH_CALLBACK}`  // 웹: 프론트엔드 라우트 경로 사용
         : 'timeegg://auth/callback';  // 모바일: 딥링크
       
       const loginUrl = `${baseLoginUrl}?redirect_uri=${encodeURIComponent(redirectUri)}`;

--- a/doc/v.1.0/backend-fix-guide.md
+++ b/doc/v.1.0/backend-fix-guide.md
@@ -1,0 +1,233 @@
+# 백엔드 수정 가이드: 카카오 OAuth 리다이렉트 URL 처리
+
+## 문제 상황
+
+현재 백엔드가 카카오 OAuth 콜백 후 고정된 URL(`/api/auth/kakao/callback`)로 리다이렉트하고 있어, 프론트엔드 라우트와 불일치가 발생합니다.
+
+### 현재 동작
+1. 프론트엔드: `GET /api/auth/kakao?redirect_uri=http://localhost:8081/auth/callback` 요청
+2. 백엔드: 카카오 OAuth 인증 후 `/api/auth/kakao/callback?token=...&isNewUser=...`로 리다이렉트
+3. 문제: 프론트엔드에 `/api/auth/kakao/callback` 라우트가 없어 404 에러 발생
+
+### 기대 동작
+1. 프론트엔드: `GET /api/auth/kakao?redirect_uri=http://localhost:8081/auth/callback` 요청
+2. 백엔드: 카카오 OAuth 인증 후 프론트엔드가 전달한 `redirect_uri`로 리다이렉트
+3. 결과: 프론트엔드의 `/auth/callback` 라우트로 정상 리다이렉트
+
+---
+
+## 수정 방법
+
+### 1. `/api/auth/kakao` 엔드포인트 수정
+
+**현재 코드 (예상):**
+```typescript
+@Get('kakao')
+async kakaoLogin() {
+  // 카카오 OAuth URL 생성
+  const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?...`;
+  
+  // 카카오로 리다이렉트
+  return res.redirect(kakaoAuthUrl);
+}
+```
+
+**수정 후 코드:**
+```typescript
+@Get('kakao')
+async kakaoLogin(
+  @Query('redirect_uri') redirectUri?: string,
+  @Res() res: Response,
+) {
+  // redirect_uri 파라미터 받기
+  // 웹: http://localhost:8081/auth/callback
+  // 모바일: timeegg://auth/callback
+  
+  // 카카오 OAuth URL 생성 시 redirect_uri 전달
+  const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirectUri || DEFAULT_REDIRECT_URI)}&response_type=code`;
+  
+  // 카카오로 리다이렉트
+  return res.redirect(kakaoAuthUrl);
+}
+```
+
+### 2. 카카오 OAuth 콜백 처리 수정
+
+**현재 코드 (예상):**
+```typescript
+@Get('kakao/callback')
+async kakaoCallback(
+  @Query('code') code: string,
+  @Res() res: Response,
+) {
+  // 카카오에서 받은 code로 토큰 발급
+  const token = await this.authService.getKakaoToken(code);
+  
+  // 고정된 URL로 리다이렉트
+  return res.redirect(`/api/auth/kakao/callback?token=${token}&isNewUser=${isNewUser}`);
+}
+```
+
+**수정 후 코드:**
+```typescript
+@Get('kakao/callback')
+async kakaoCallback(
+  @Query('code') code: string,
+  @Query('state') state?: string, // redirect_uri를 state로 전달
+  @Res() res: Response,
+) {
+  // 카카오에서 받은 code로 토큰 발급
+  const { token, isNewUser } = await this.authService.getKakaoToken(code);
+  
+  // state에서 원래 redirect_uri 복원
+  const redirectUri = state ? decodeURIComponent(state) : DEFAULT_REDIRECT_URI;
+  
+  // 프론트엔드가 요청한 redirect_uri로 리다이렉트
+  return res.redirect(`${redirectUri}?token=${token}&isNewUser=${isNewUser}`);
+}
+```
+
+### 3. 카카오 OAuth URL 생성 시 state 파라미터 추가
+
+**수정 후 코드:**
+```typescript
+@Get('kakao')
+async kakaoLogin(
+  @Query('redirect_uri') redirectUri?: string,
+  @Res() res: Response,
+) {
+  const finalRedirectUri = redirectUri || DEFAULT_REDIRECT_URI;
+  
+  // redirect_uri를 state로 전달 (카카오 OAuth 표준 방식)
+  const state = encodeURIComponent(finalRedirectUri);
+  
+  // 카카오 OAuth URL 생성
+  const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${encodeURIComponent(BACKEND_CALLBACK_URL)}&response_type=code&state=${state}`;
+  
+  // 카카오로 리다이렉트
+  return res.redirect(kakaoAuthUrl);
+}
+```
+
+---
+
+## 상세 구현 예시 (NestJS 기준)
+
+### AuthController 수정
+
+```typescript
+import { Controller, Get, Query, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { AuthService } from './auth.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Get('kakao')
+  async kakaoLogin(
+    @Query('redirect_uri') redirectUri?: string,
+    @Res() res: Response,
+  ) {
+    // 기본 redirect_uri 설정 (fallback)
+    const DEFAULT_REDIRECT_URI = 'http://localhost:8081/auth/callback';
+    const finalRedirectUri = redirectUri || DEFAULT_REDIRECT_URI;
+    
+    // redirect_uri를 state로 전달 (카카오 OAuth 표준)
+    const state = encodeURIComponent(finalRedirectUri);
+    
+    // 백엔드 콜백 URL (카카오에 등록된 redirect_uri)
+    const BACKEND_CALLBACK_URL = `${process.env.API_BASE_URL}/api/auth/kakao/callback`;
+    
+    // 카카오 OAuth URL 생성
+    const kakaoAuthUrl = this.authService.buildKakaoAuthUrl({
+      redirectUri: BACKEND_CALLBACK_URL,
+      state,
+    });
+    
+    // 카카오로 리다이렉트
+    return res.redirect(kakaoAuthUrl);
+  }
+
+  @Get('kakao/callback')
+  async kakaoCallback(
+    @Query('code') code: string,
+    @Query('state') state?: string,
+    @Res() res: Response,
+  ) {
+    try {
+      // 카카오에서 받은 code로 토큰 발급
+      const { token, isNewUser } = await this.authService.handleKakaoCallback(code);
+      
+      // state에서 원래 redirect_uri 복원
+      const DEFAULT_REDIRECT_URI = 'http://localhost:8081/auth/callback';
+      const redirectUri = state ? decodeURIComponent(state) : DEFAULT_REDIRECT_URI;
+      
+      // 프론트엔드가 요청한 redirect_uri로 리다이렉트
+      return res.redirect(`${redirectUri}?token=${token}&isNewUser=${isNewUser}`);
+    } catch (error) {
+      // 에러 처리
+      const redirectUri = state ? decodeURIComponent(state) : 'http://localhost:8081/auth/callback';
+      return res.redirect(`${redirectUri}?error=${encodeURIComponent(error.message)}`);
+    }
+  }
+}
+```
+
+---
+
+## 프론트엔드 요청 형식
+
+### 웹 환경
+```
+GET /api/auth/kakao?redirect_uri=http://localhost:8081/auth/callback
+```
+
+### 모바일 환경
+```
+GET /api/auth/kakao?redirect_uri=timeegg://auth/callback
+```
+
+---
+
+## 보안 고려사항
+
+1. **redirect_uri 검증**: 허용된 도메인만 리다이렉트하도록 화이트리스트 검증
+   ```typescript
+   const ALLOWED_REDIRECT_URIS = [
+     'http://localhost:8081',
+     'https://timeegg.com',
+     'timeegg://',
+   ];
+   
+   const isValidRedirectUri = (uri: string) => {
+     return ALLOWED_REDIRECT_URIS.some(allowed => uri.startsWith(allowed));
+   };
+   ```
+
+2. **state 파라미터 검증**: CSRF 공격 방지를 위해 state 값 검증
+
+---
+
+## 테스트 방법
+
+1. **웹 환경 테스트**
+   ```bash
+   curl "http://localhost:3000/api/auth/kakao?redirect_uri=http://localhost:8081/auth/callback"
+   ```
+   - 카카오 로그인 후 `http://localhost:8081/auth/callback?token=...&isNewUser=...`로 리다이렉트되어야 함
+
+2. **모바일 환경 테스트**
+   ```bash
+   curl "http://localhost:3000/api/auth/kakao?redirect_uri=timeegg://auth/callback"
+   ```
+   - 카카오 로그인 후 `timeegg://auth/callback?token=...&isNewUser=...`로 리다이렉트되어야 함
+
+---
+
+## 참고사항
+
+- 현재 프론트엔드에는 임시 해결책으로 `/app/api/auth/kakao/callback.tsx` 라우트가 추가되어 있습니다.
+- 백엔드 수정이 완료되면 해당 임시 라우트는 제거해야 합니다.
+- 카카오 OAuth의 `state` 파라미터는 CSRF 방지와 함께 추가 데이터 전달 용도로 사용할 수 있습니다.
+


### PR DESCRIPTION
- AUTH_CALLBACK 라우트 상수 추가 (/auth/callback)
- useKakaoLogin에서 redirectUri를 상수로 사용하도록 수정
- 백엔드가 /api/auth/kakao/callback으로 리다이렉트하는 문제 임시 해결
  - app/api/auth/kakao/callback.tsx 라우트 추가
- 백엔드 수정 가이드 문서 추가 (backend-fix-guide.md)

## 📌 관련 이슈 (Task ID)
 
- ID: backend redirectURL update전, 임시 라우터 연결

## 📝 작업 내용 (Details)

- [ ]
- [ ]

## 📸 스크린샷 (Screenshots)

## 🧐 리뷰 포인트 (Review Point)

-

## ✅ 체크리스트 (Checklist)

- [ ] 컨벤션(커밋, 브랜치 네이밍)을 준수했나요?
- [ ] 불필요한 콘솔 로그(console.log)나 주석을 제거했나요?
- [ ] 실행 시 에러가 발생하지 않나요?
