### PR TITLE
feat/AUTH-00

### DIFF
--- a/components/onboarding/components/friend-consent-step/index.tsx
+++ b/components/onboarding/components/friend-consent-step/index.tsx
@@ -8,6 +8,11 @@ import { Image } from 'expo-image';
 import { Pressable, Text, View } from 'react-native';
 import { styles } from './styles';
 
+// 이미지 리소스
+const imgBackIcon = require('@/assets/icons/<.png');
+const imgFriendIcon = require('@/assets/icons/friend.png');
+const imgShieldIcon = require('@/assets/icons/shield.png');
+
 interface FriendConsentStepProps {
   isLoading: boolean;
   onConsent: () => void;
@@ -22,7 +27,7 @@ export function FriendConsentStep({ isLoading, onConsent }: FriendConsentStepPro
       {/* 헤더 영역 */}
       <View style={styles.header}>
         <Pressable style={styles.backButton}>
-          <Image source={require('@/assets/icons/<.png')} style={styles.backIcon} />
+          <Image source={imgBackIcon} style={styles.backIcon} contentFit="contain" />
         </Pressable>
         <View style={styles.progressContainer}>
           <View style={styles.progressActive} />
@@ -54,7 +59,7 @@ export function FriendConsentStep({ isLoading, onConsent }: FriendConsentStepPro
           {/* 카드 1: 내 친구 자동 매칭 */}
           <View style={styles.card}>
             <View style={styles.cardIconContainer}>
-              <Image source={require('@/assets/icons/friend.png')} style={styles.cardIcon} />
+              <Image source={imgFriendIcon} style={styles.cardIcon} contentFit="contain" />
             </View>
             <View style={styles.cardContent}>
               <Text style={styles.cardTitle}>내 친구 자동 매칭</Text>
@@ -68,7 +73,7 @@ export function FriendConsentStep({ isLoading, onConsent }: FriendConsentStepPro
           {/* 카드 2: 안전한 개인정보 */}
           <View style={styles.card}>
             <View style={styles.cardIconContainer}>
-              <Image source={require('@/assets/icons/shield.png')} style={styles.cardIcon} />
+              <Image source={imgShieldIcon} style={styles.cardIcon} contentFit="contain" />
             </View>
             <View style={styles.cardContent}>
               <Text style={styles.cardTitle}>안전한 개인정보</Text>

--- a/components/onboarding/components/login-step/index.tsx
+++ b/components/onboarding/components/login-step/index.tsx
@@ -8,10 +8,10 @@ import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-na
 import Icon from 'react-native-remix-icon';
 import { createResponsiveStyles } from './styles';
 
-// Figma MCP에서 제공한 배경 이미지 URL
-const imgGeminiGeneratedImage =
-  'http://localhost:3845/assets/1f32b8de05056d1ec9a5f74cec54c29176823019.png';
-const imgEllipse = 'http://localhost:3845/assets/5fd04f478f1b1f756c49f81b5c65ba151f3c22eb.svg';
+// 이미지 리소스
+const imgGeminiGeneratedImage = require('@/assets/icons/onboarding_page_icon.png');
+const imgLocationPin = require('@/assets/icons/locationPin.png');
+const imgFriend = require('@/assets/icons/friend.png');
 
 interface LoginStepProps {
   isLoading: boolean;
@@ -49,11 +49,7 @@ export function LoginStep({ isLoading, onKakaoLogin }: LoginStepProps) {
                   <Text style={styles.cardDescription}>원하는 장소에 타임캡슐을 묻어보세요</Text>
                 </View>
                 <View style={styles.cardIconRight}>
-                  <Image
-                    source={require('../../../../assets/icons/locationPin.png')}
-                    style={styles.cardIcon}
-                    contentFit="contain"
-                  />
+                  <Image source={imgLocationPin} style={styles.cardIcon} contentFit="contain" />
                 </View>
               </View>
             </View>
@@ -63,11 +59,7 @@ export function LoginStep({ isLoading, onKakaoLogin }: LoginStepProps) {
           <View style={styles.cardSecond}>
             <View style={styles.cardSecondContent}>
               <View style={styles.cardIconLeft}>
-                <Image
-                  source={require('../../../../assets/icons/friend.png')}
-                  style={styles.cardIconSecond}
-                  contentFit="contain"
-                />
+                <Image source={imgFriend} style={styles.cardIconSecond} contentFit="contain" />
               </View>
               <View style={styles.cardSecondTextContainer}>
                 <Text style={styles.cardTitle}>친구와 함께</Text>
@@ -83,7 +75,11 @@ export function LoginStep({ isLoading, onKakaoLogin }: LoginStepProps) {
           <View style={styles.backgroundImagesWrapper}>
             <View style={styles.backgroundImagesContainer}>
               {/* <Image source={{ uri: imgEllipse }} style={styles.ellipseImage} /> */}
-              <Image source={{ uri: imgGeminiGeneratedImage }} style={styles.bunnyImage} />
+              <Image
+                source={imgGeminiGeneratedImage}
+                style={styles.bunnyImage}
+                contentFit="contain"
+              />
             </View>
 
             {/* 카카오 로그인 버튼 (이미지 위에 배치) */}


### PR DESCRIPTION
## 📌 관련 이슈 (Task ID)

- ID: feat/AUTH-00

## 📝 작업 내용 (Details)

- [x] 로컬호스트 URL(http://localhost:3845/...)을 로컬 assets 이미지로 교체
- [x] 이미지 리소스를 파일 상단에 선언하는 방식으로 통일
- [x] 모든 Image 컴포넌트에 contentFit="contain" 속성 추가
- [x] 경로 alias(@/assets/...) 사용으로 프로젝트 내 일관성 유지

## 📸 스크린샷 (Screenshots)

스크린샷 없음 (기능 변경 없이 내부 리소스 처리 방식 개선)

## 🧐 리뷰 포인트 (Review Point)

- `login-step`과 `friend-consent-step` 컴포넌트의 이미지 리소스 처리 방식이 통일되었는지 확인
- 모든 Image 컴포넌트에 contentFit 속성이 올바르게 적용되었는지 확인
- 로컬호스트 URL이 완전히 제거되고 로컬 assets 경로로 교체되었는지 확인

## ✅ 체크리스트 (Checklist)

- [x] 컨벤션(커밋, 브랜치 네이밍)을 준수했나요?
  - 커밋 메시지: `refactor: 온보딩 컴포넌트 로컬호스트 이미지 URL을 assets 리소스로 교체 및 스타일 통일`
  - 브랜치: `feat/AUTH-00`
- [x] 불필요한 콘솔 로그(console.log)나 주석을 제거했나요?
  - 콘솔 로그 없음 확인
  - 불필요한 주석 없음
- [x] 실행 시 에러가 발생하지 않나요?
  - 린터 에러 없음 확인
  - 이미지 경로 정상 작동 확인