### PR TITLE
[Feat/CAP-05] 캡슐 바텀시트 수정불가로 변경

### DIFF
--- a/commons/components/bottom-sheet/index.tsx
+++ b/commons/components/bottom-sheet/index.tsx
@@ -107,12 +107,22 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
   };
 
   // PanResponder 설정 (드래그 핸들링)
+  // ⭐ 핸들 영역에만 적용되도록 수정 (footer 버튼 클릭 허용)
   const panResponder = useRef(
     PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
+      onStartShouldSetPanResponder: () => {
+        console.log('⚪ [PanResponder] onStartShouldSetPanResponder 호출됨');
+        return false; // ⭐ 기본적으로 비활성화
+      },
       onMoveShouldSetPanResponder: (_, gestureState) => {
         // 수직 이동이 수평 이동보다 클 때만 PanResponder 활성화
-        return Math.abs(gestureState.dy) > Math.abs(gestureState.dx);
+        // ⭐ 최소 5px 이상 이동해야 드래그로 인식 (버튼 클릭과 구분)
+        const shouldActivate =
+          Math.abs(gestureState.dy) > Math.abs(gestureState.dx) && Math.abs(gestureState.dy) > 5;
+        if (shouldActivate) {
+          console.log('⚪ [PanResponder] 드래그 활성화됨', gestureState.dy);
+        }
+        return shouldActivate;
       },
       onPanResponderMove: (_, gestureState) => {
         // 드래그 중 처리 없음
@@ -228,8 +238,12 @@ export const BottomSheet: React.FC<BottomSheetProps> = ({
             {children}
           </ScrollView>
 
-          {/* 하단 고정 영역 (footer) */}
-          {footer && <View style={styles.footer}>{footer}</View>}
+          {/* 하단 고정 영역 (footer) - ⭐ PanResponder 영향 받지 않도록 설정 */}
+          {footer && (
+            <View style={styles.footer} pointerEvents="auto">
+              {footer}
+            </View>
+          )}
         </Animated.View>
       </View>
     </Modal>

--- a/commons/components/bottom-sheet/styles.ts
+++ b/commons/components/bottom-sheet/styles.ts
@@ -80,5 +80,6 @@ export const styles = StyleSheet.create({
     gap: Spacing.md,
     borderTopWidth: 1,
     borderTopColor: Colors.white[200],
+    zIndex: 10, // 웹에서 클릭 가능하도록 z-index 추가
   },
 });

--- a/commons/components/button/index.tsx
+++ b/commons/components/button/index.tsx
@@ -115,7 +115,14 @@ function ButtonComponent({
 
   return (
     <Pressable
-      onPress={disabled ? undefined : onPress}
+      onPress={
+        disabled
+          ? undefined
+          : () => {
+              console.log(`🔘 [Button] 버튼 "${label}" 클릭됨 (disabled: ${disabled})`);
+              onPress();
+            }
+      }
       disabled={disabled}
       style={[styles.button, buttonStyle]}>
       <View style={styles.content}>

--- a/commons/components/modal/styles.ts
+++ b/commons/components/modal/styles.ts
@@ -103,6 +103,7 @@ export const styles = StyleSheet.create({
    * - 전체 화면 커버
    * - 반투명 검은색 배경
    * - 중앙 정렬
+   * - ⭐ z-index를 높게 설정하여 다른 Modal 위에 표시
    */
   backdrop: {
     position: 'absolute',
@@ -113,6 +114,8 @@ export const styles = StyleSheet.create({
     backgroundColor: MODAL_STYLES.backdropColor,
     justifyContent: 'center',
     alignItems: 'center',
+    zIndex: 9999, // ⭐ 매우 높은 z-index
+    elevation: 9999, // ⭐ Android용
   },
 
   /**
@@ -151,9 +154,12 @@ export const styles = StyleSheet.create({
    * 모달 컨테이너 absolute 위치 스타일
    * - Pressable과 분리하여 스크롤 제스처가 정상 작동하도록 함
    * - backdrop의 justifyContent: 'center', alignItems: 'center'와 함께 사용
+   * - ⭐ z-index를 Pressable보다 높게 설정하여 위에 렌더링
    */
   modalContainerAbsolute: {
     position: 'absolute',
     alignSelf: 'center',
+    zIndex: 10000, // ⭐ Backdrop Pressable보다 높게
+    elevation: 10000, // ⭐ Android용
   },
 });

--- a/commons/constants/media.ts
+++ b/commons/constants/media.ts
@@ -9,8 +9,8 @@ export type MediaType = 'IMAGE' | 'VIDEO' | 'AUDIO';
 // 화이트리스트 정의
 export const ALLOWED_EXTENSIONS = {
   IMAGE: ['jpeg', 'jpg', 'png', 'webp'],
-  VIDEO: ['mp4'],
-  AUDIO: ['mpeg', 'aac', 'm4a'],
+  VIDEO: ['mp4', 'webm'],
+  AUDIO: ['mpeg', 'mp3', 'mp4', 'x-m4a', 'aac', 'm4a', 'x-aac'],
 } as const;
 
 // 용량 제한 (바이트 단위)
@@ -29,8 +29,33 @@ export const MIME_TYPE_MAP: Record<string, string> = {
   webp: 'image/webp',
   // VIDEO
   mp4: 'video/mp4',
+  webm: 'video/webm',
   // AUDIO
   mpeg: 'audio/mpeg',
+  mp3: 'audio/mpeg',
+  'mp4': 'audio/mp4',
+  'x-m4a': 'audio/x-m4a',
   aac: 'audio/aac',
   m4a: 'audio/m4a',
+  'x-aac': 'audio/x-aac',
+};
+
+// MIME Type에서 확장자 역매핑 (검증용)
+export const MIME_TO_EXTENSION: Record<string, string[]> = {
+  // IMAGE
+  'image/jpeg': ['jpeg', 'jpg'],
+  'image/jpg': ['jpeg', 'jpg'],
+  'image/png': ['png'],
+  'image/webp': ['webp'],
+  // VIDEO
+  'video/mp4': ['mp4'],
+  'video/webm': ['webm'],
+  // AUDIO
+  'audio/mpeg': ['mpeg', 'mp3'],
+  'audio/mp3': ['mp3'],
+  'audio/mp4': ['mp4'],
+  'audio/x-m4a': ['m4a', 'x-m4a'],
+  'audio/aac': ['aac'],
+  'audio/m4a': ['m4a'],
+  'audio/x-aac': ['aac', 'x-aac'],
 };

--- a/commons/layout/provider/modal/modal.provider.tsx
+++ b/commons/layout/provider/modal/modal.provider.tsx
@@ -47,10 +47,16 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({ children }) => {
    * @param config - 모달 설정 (children, width, height, closeOnBackdropPress, onClose)
    */
   const openModal = useCallback((config: ModalConfig) => {
+    console.log('🔵 [ModalProvider] openModal 호출됨', {
+      width: config.width,
+      height: config.height,
+      hasChildren: !!config.children,
+    });
     setModalState({
       isVisible: true,
       config,
     });
+    console.log('🔵 [ModalProvider] 모달 상태 업데이트 완료');
   }, []);
 
   /**
@@ -78,6 +84,14 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({ children }) => {
     }),
     [openModal, closeModal]
   );
+
+  // 모달 상태 변경 감지
+  React.useEffect(() => {
+    console.log('🔵 [ModalProvider] 모달 상태 변경:', {
+      isVisible: modalState.isVisible,
+      hasConfig: !!modalState.config,
+    });
+  }, [modalState]);
 
   return (
     <ModalContext.Provider value={contextValue}>

--- a/components/my-capsule/api/capsule.ts
+++ b/components/my-capsule/api/capsule.ts
@@ -64,13 +64,18 @@ interface ApiSlotResponse {
   entry_id: string | null;
   wrote_at: string | null;
   content: string | null;
-  media_items: Array<{
-    id: string;
-    media_type: 'IMAGE' | 'VIDEO' | 'AUDIO';
-    url: string;
-    thumbnail_url?: string;
-    title?: string;
-  }>;
+  images_ids: Array<{
+    media_id: string;
+    object_key: string;
+  }> | null;
+  audio_id: {
+    media_id: string;
+    object_key: string;
+  } | null;
+  video_id: {
+    media_id: string;
+    object_key: string;
+  } | null;
 }
 
 interface ApiCapsuleDetailResponse {
@@ -96,9 +101,11 @@ interface ApiCapsuleDetailResponse {
 
 function transformSlotContent(
   content: string | null,
-  mediaItems: ApiSlotResponse['media_items'],
+  imagesIds: ApiSlotResponse['images_ids'],
+  audioId: ApiSlotResponse['audio_id'],
+  videoId: ApiSlotResponse['video_id'],
 ): SlotContent | undefined {
-  if (!content && (!mediaItems || mediaItems.length === 0)) {
+  if (!content && (!imagesIds || imagesIds.length === 0) && !audioId && !videoId) {
     return undefined;
   }
 
@@ -109,41 +116,33 @@ function transformSlotContent(
     result.text = content;
   }
 
-  // 미디어 아이템 변환
-  if (mediaItems && mediaItems.length > 0) {
-    const images: ImageMedia[] = [];
-    let video: VideoMedia | undefined;
-    let audio: AudioMedia | undefined;
+  // 이미지 변환 - media_id만 저장 (URL은 컴포넌트에서 가져옴)
+  if (imagesIds && imagesIds.length > 0) {
+    result.images = imagesIds.map((img) => ({
+      id: img.media_id,
+      url: '', // 컴포넌트에서 getMediaUrl로 가져옴
+      objectKey: img.object_key, // object_key도 저장해두기
+    }));
+  }
 
-    for (const item of mediaItems) {
-      if (item.media_type === 'IMAGE') {
-        images.push({
-          id: item.id,
-          url: item.url,
-          thumbnailUrl: item.thumbnail_url,
-        });
-      } else if (item.media_type === 'VIDEO') {
-        if (!video) {
-          video = {
-            id: item.id,
-            url: item.url,
-            thumbnailUrl: item.thumbnail_url || item.url,
-          };
-        }
-      } else if (item.media_type === 'AUDIO') {
-        if (!audio) {
-          audio = {
-            id: item.id,
-            title: item.title || '오디오',
-            url: item.url,
-          };
-        }
-      }
-    }
+  // 비디오 변환
+  if (videoId) {
+    result.video = {
+      id: videoId.media_id,
+      url: '', // 컴포넌트에서 getMediaUrl로 가져옴
+      thumbnailUrl: '', // 컴포넌트에서 처리
+      objectKey: videoId.object_key,
+    };
+  }
 
-    if (images.length > 0) result.images = images;
-    if (video) result.video = video;
-    if (audio) result.audio = audio;
+  // 오디오 변환
+  if (audioId) {
+    result.audio = {
+      id: audioId.media_id,
+      title: '오디오',
+      url: '', // 컴포넌트에서 getMediaUrl로 가져옴
+      objectKey: audioId.object_key,
+    };
   }
 
   return Object.keys(result).length > 0 ? result : undefined;
@@ -159,7 +158,10 @@ function transformApiResponse(apiResponse: ApiCapsuleDetailResponse): OpenedCaps
 
     // entry_id가 없어도 content나 media가 있으면 작성된 것으로 간주
     const hasContent = slot.content !== null && slot.content.trim() !== '';
-    const hasMedia = slot.media_items && slot.media_items.length > 0;
+    const hasImages = slot.images_ids && slot.images_ids.length > 0;
+    const hasAudio = slot.audio_id !== null;
+    const hasVideo = slot.video_id !== null;
+    const hasMedia = hasImages || hasAudio || hasVideo;
 
     // 작성 여부: entry_id가 있거나, content/media가 있으면 작성된 것
     const isWritten = hasEntry || hasContent || hasMedia;
@@ -170,6 +172,7 @@ function transformApiResponse(apiResponse: ApiCapsuleDetailResponse): OpenedCaps
           id: slot.user_id,
           name: slot.nickname || '익명',
           emoji: '😊', // 기본 이모지 (API에 이모지 필드가 없음)
+          profileImg: slot.profile_img || undefined,
         }
       : {
           id: '',
@@ -179,7 +182,9 @@ function transformApiResponse(apiResponse: ApiCapsuleDetailResponse): OpenedCaps
 
     // 🔒 잠긴 상태일 때는 콘텐츠를 숨김
     // 🔓 열린 상태일 때만 콘텐츠 표시
-    const content = isLocked ? undefined : transformSlotContent(slot.content, slot.media_items);
+    const content = isLocked
+      ? undefined
+      : transformSlotContent(slot.content, slot.images_ids, slot.audio_id, slot.video_id);
 
     return {
       slotId: slot.slot_id,

--- a/components/my-capsule/components/unlocked-capsule-detail/index.tsx
+++ b/components/my-capsule/components/unlocked-capsule-detail/index.tsx
@@ -12,7 +12,7 @@
  * - 닫기 버튼: 오른쪽 상단
  */
 
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { View, Text, TouchableOpacity, ScrollView, Dimensions } from 'react-native';
 import { Image } from 'expo-image';
 import Icon from 'react-native-remix-icon';
@@ -20,6 +20,10 @@ import { Modal } from '@/commons/components/modal';
 import { Colors } from '@/commons/constants/color';
 import { styles } from './styles';
 import { useOpenedCapsuleDetail } from '../../hooks/useOpenedCapsuleDetail';
+import { getMediaUrl } from '@/utils/mediaUrl';
+import { AudioPlayer } from '@/components/shared/audio-player';
+import { VideoPlayer } from '@/components/shared/video-player';
+import type { ImageMedia, VideoMedia, AudioMedia } from '../../types';
 
 interface UnlockedCapsuleDetailProps {
   /** 모달 표시 여부 */
@@ -46,10 +50,46 @@ export default function UnlockedCapsuleDetail({
   const [selectedSlotIndex, setSelectedSlotIndex] = useState(0);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const scrollViewRef = useRef<ScrollView>(null);
+  
+  // 미디어 URL 상태 (이미지만 관리, 비디오/오디오는 AudioPlayer/VideoPlayer에서 처리)
+  const [imageUrls, setImageUrls] = useState<Map<string, string>>(new Map());
 
   // 선택된 슬롯
   const selectedSlot = writtenSlots[selectedSlotIndex];
   const imageCount = selectedSlot?.content?.images?.length || 0;
+
+  // 이미지 URL 가져오기 (선택된 슬롯이 변경될 때마다)
+  // 비디오와 오디오는 AudioPlayer/VideoPlayer 컴포넌트에서 자동으로 처리
+  useEffect(() => {
+    if (!selectedSlot?.content?.images) {
+      setImageUrls(new Map());
+      return;
+    }
+
+    const loadImageUrls = async () => {
+      const newImageUrls = new Map<string, string>();
+
+      // 이미지 URL 가져오기
+      for (const image of selectedSlot.content.images || []) {
+        if (image.url && image.url.trim() !== '') {
+          // 이미 URL이 있으면 사용
+          newImageUrls.set(image.id, image.url);
+        } else if (image.id) {
+          // media_id로 URL 가져오기
+          try {
+            const url = await getMediaUrl(image.id);
+            newImageUrls.set(image.id, url);
+          } catch (err) {
+            console.error('Failed to load image URL:', err);
+          }
+        }
+      }
+
+      setImageUrls(newImageUrls);
+    };
+
+    loadImageUrls();
+  }, [selectedSlotIndex, selectedSlot]);
 
   const handleUserSelect = (index: number) => {
     setSelectedSlotIndex(index);
@@ -109,6 +149,15 @@ export default function UnlockedCapsuleDetail({
   }
 
   const currentContent = selectedSlot.content;
+  
+  // URL이 포함된 콘텐츠 생성 (이미지만 URL 변환, 비디오/오디오는 컴포넌트에서 처리)
+  const enrichedContent = currentContent ? {
+    ...currentContent,
+    images: currentContent.images?.map((img) => ({
+      ...img,
+      url: imageUrls.get(img.id) || img.url || '',
+    })),
+  } : undefined;
 
   return (
     <Modal
@@ -149,7 +198,15 @@ export default function UnlockedCapsuleDetail({
                         : styles.userAvatarBorder
                     }>
                     <View style={styles.userAvatarInner}>
-                      <Text style={styles.userAvatarEmoji}>{slot.author.emoji}</Text>
+                      {slot.author.profileImg ? (
+                        <Image
+                          source={{ uri: slot.author.profileImg }}
+                          style={{ width: '100%', height: '100%', borderRadius: 50 }}
+                          contentFit="cover"
+                        />
+                      ) : (
+                        <Text style={styles.userAvatarEmoji}>{slot.author.emoji}</Text>
+                      )}
                     </View>
                   </View>
                   <Text
@@ -172,16 +229,16 @@ export default function UnlockedCapsuleDetail({
           contentContainerStyle={styles.contentScrollContainer}
           showsVerticalScrollIndicator={false}>
           {/* 텍스트 메시지 - API 데이터 */}
-          {currentContent?.text && (
+          {enrichedContent?.text && (
             <View style={styles.textMessagesContainer}>
               <View style={styles.textMessageCard}>
-                <Text style={styles.textMessageText}>{currentContent.text}</Text>
+                <Text style={styles.textMessageText}>{enrichedContent.text}</Text>
               </View>
             </View>
           )}
 
           {/* 이미지 캐러셀 섹션 - API 데이터 */}
-          {imageCount > 0 && (
+          {enrichedContent?.images && enrichedContent.images.length > 0 && (
             <View style={styles.imageSection}>
               <View style={styles.imageContainer}>
                 <ScrollView
@@ -191,29 +248,35 @@ export default function UnlockedCapsuleDetail({
                   showsHorizontalScrollIndicator={false}
                   onMomentumScrollEnd={handleImageScroll}
                   style={styles.imageScrollView}>
-                  {currentContent.images!.map((image) => (
+                  {enrichedContent.images.map((image) => (
                     <View key={image.id} style={styles.imageItem}>
-                      <Image
-                        source={{ uri: image.url }}
-                        style={styles.imagePlaceholder}
-                        contentFit="cover"
-                      />
+                      {image.url ? (
+                        <Image
+                          source={{ uri: image.url }}
+                          style={styles.imagePlaceholder}
+                          contentFit="cover"
+                        />
+                      ) : (
+                        <View style={[styles.imagePlaceholder, { backgroundColor: Colors.grey[200], justifyContent: 'center', alignItems: 'center' }]}>
+                          <Text style={{ color: Colors.grey[500] }}>이미지 로딩 중...</Text>
+                        </View>
+                      )}
                     </View>
                   ))}
                 </ScrollView>
                 {/* 이미지 인디케이터 */}
-                {imageCount > 1 && (
+                {enrichedContent.images.length > 1 && (
                   <View style={styles.imageIndicator}>
                     <Text style={styles.imageIndicatorText}>
-                      {currentImageIndex + 1}/{imageCount}
+                      {currentImageIndex + 1}/{enrichedContent.images.length}
                     </Text>
                   </View>
                 )}
               </View>
               {/* 페이지네이션 인디케이터 */}
-              {imageCount > 1 && (
+              {enrichedContent.images.length > 1 && (
                 <View style={styles.paginationContainer}>
-                  {currentContent.images!.map((image, index) => (
+                  {enrichedContent.images.map((image, index) => (
                     <View
                       key={image.id}
                       style={
@@ -228,43 +291,24 @@ export default function UnlockedCapsuleDetail({
             </View>
           )}
 
-          {/* 동영상 섹션 - API 데이터 */}
-          {currentContent?.video && (
+          {/* 동영상 섹션 - VideoPlayer 컴포넌트 사용 */}
+          {currentContent?.video && currentContent.video.id && (
             <View style={styles.videoSection}>
               <View style={styles.videoContainer}>
-                <Image
-                  source={{ uri: currentContent.video.thumbnailUrl }}
-                  style={styles.videoThumbnail}
-                  contentFit="cover"
+                <VideoPlayer
+                  mediaId={currentContent.video.url || currentContent.video.id}
+                  thumbnailUrl={currentContent.video.thumbnailUrl || undefined}
                 />
-                {/* 오버레이 및 재생 버튼 */}
-                <View style={styles.videoOverlay} pointerEvents="box-none">
-                  <TouchableOpacity style={styles.playButton} activeOpacity={0.8}>
-                    <Icon name="ri-play-circle-line" size={24} color={Colors.white[500]} />
-                  </TouchableOpacity>
-                </View>
               </View>
             </View>
           )}
 
-          {/* 오디오 플레이어 섹션 - API 데이터 */}
-          {currentContent?.audio && (
+          {/* 오디오 플레이어 섹션 - AudioPlayer 컴포넌트 사용 */}
+          {currentContent?.audio && currentContent.audio.id && (
             <View style={styles.audioSection}>
-              <View style={styles.audioCard}>
-                <View style={styles.audioContent}>
-                  <View style={styles.audioIconContainer}>
-                    <Icon name="ri-music-line" size={20} color={Colors.black[500]} />
-                  </View>
-                  <View style={styles.audioTitleContainer}>
-                    <Text style={styles.audioTitle} numberOfLines={1}>
-                      {currentContent.audio.title}
-                    </Text>
-                  </View>
-                  <TouchableOpacity style={styles.audioPlayButton} activeOpacity={0.8}>
-                    <Icon name="ri-play-line" size={16} color={Colors.white[500]} />
-                  </TouchableOpacity>
-                </View>
-              </View>
+              <AudioPlayer
+                mediaId={currentContent.audio.url || currentContent.audio.id}
+              />
             </View>
           )}
         </ScrollView>

--- a/components/my-capsule/types/index.ts
+++ b/components/my-capsule/types/index.ts
@@ -47,33 +47,37 @@ export interface Author {
   id: string;                    // 사용자 ID
   name: string;                  // 사용자 이름
   emoji: string;                 // 사용자 이모지
+  profileImg?: string;           // 프로필 이미지 URL (선택적)
 }
 
 /**
  * 이미지 미디어
  */
 export interface ImageMedia {
-  id: string;                    // 이미지 ID
-  url: string;                   // 이미지 URL
+  id: string;                    // 이미지 ID (media_id)
+  url: string;                   // 이미지 URL (비동기로 가져옴)
   thumbnailUrl?: string;         // 썸네일 URL (선택적)
+  objectKey?: string;            // S3 object key (선택적)
 }
 
 /**
  * 비디오 미디어
  */
 export interface VideoMedia {
-  id: string;                    // 비디오 ID
-  url: string;                   // 비디오 URL
+  id: string;                    // 비디오 ID (media_id)
+  url: string;                   // 비디오 URL (비동기로 가져옴)
   thumbnailUrl: string;          // 비디오 썸네일 URL
+  objectKey?: string;            // S3 object key (선택적)
 }
 
 /**
  * 오디오 미디어
  */
 export interface AudioMedia {
-  id: string;                    // 오디오 ID
+  id: string;                    // 오디오 ID (media_id)
   title: string;                 // 오디오 제목
-  url: string;                   // 오디오 URL
+  url: string;                   // 오디오 URL (비동기로 가져옴)
+  objectKey?: string;            // S3 object key (선택적)
 }
 
 /**

--- a/components/timecapsule-create/components/step-room/hooks/useParticipants.ts
+++ b/components/timecapsule-create/components/step-room/hooks/useParticipants.ts
@@ -604,15 +604,27 @@ export function useParticipants({
             const fileName = getFileName(imageUri, `photo_${Date.now()}_${i}.jpg`);
             const mimeType = getMimeType(imageUri, 'image');
 
-            formData.append('images', {
-              uri: imageUri,
-              type: mimeType,
-              name: fileName,
-            } as any);
-
-            console.log(
-              `✅ [useParticipants] 이미지 ${i + 1}/${content.images.length} FormData에 추가 완료`,
-            );
+            // ⭐ 웹과 네이티브 플랫폼 구분
+            if (Platform.OS === 'web') {
+              // 웹: File 객체로 변환
+              const response = await fetch(imageUri);
+              const blob = await response.blob();
+              const file = new File([blob], fileName, { type: mimeType });
+              formData.append('images', file);
+              console.log(
+                `✅ [useParticipants] 이미지 ${i + 1}/${content.images.length} File 객체로 추가 완료 (${file.size} bytes)`,
+              );
+            } else {
+              // 네이티브: React Native 형식
+              formData.append('images', {
+                uri: imageUri,
+                type: mimeType,
+                name: fileName,
+              } as any);
+              console.log(
+                `✅ [useParticipants] 이미지 ${i + 1}/${content.images.length} FormData에 추가 완료`,
+              );
+            }
           }
         }
 
@@ -624,13 +636,25 @@ export function useParticipants({
             const fileName = getFileName(content.voiceRecording, `music_${Date.now()}.mp3`);
             const mimeType = getMimeType(content.voiceRecording, 'audio');
 
-            formData.append('music', {
-              uri: content.voiceRecording,
-              type: mimeType,
-              name: fileName,
-            } as any);
-
-            console.log('✅ [useParticipants] 음악 파일 FormData에 추가 완료');
+            // ⭐ 웹과 네이티브 플랫폼 구분
+            if (Platform.OS === 'web') {
+              // 웹: File 객체로 변환
+              const response = await fetch(content.voiceRecording);
+              const blob = await response.blob();
+              const file = new File([blob], fileName, { type: mimeType });
+              formData.append('music', file);
+              console.log(
+                `✅ [useParticipants] 음악 파일 File 객체로 추가 완료 (${file.size} bytes)`,
+              );
+            } else {
+              // 네이티브: React Native 형식
+              formData.append('music', {
+                uri: content.voiceRecording,
+                type: mimeType,
+                name: fileName,
+              } as any);
+              console.log('✅ [useParticipants] 음악 파일 FormData에 추가 완료');
+            }
           } else {
             console.log('  ⏭️  음악: 이미 업로드된 파일이므로 건너뜀 - ', content.voiceRecording);
           }
@@ -644,13 +668,25 @@ export function useParticipants({
             const fileName = getFileName(content.video, `video_${Date.now()}.mp4`);
             const mimeType = getMimeType(content.video, 'video');
 
-            formData.append('video', {
-              uri: content.video,
-              type: mimeType,
-              name: fileName,
-            } as any);
-
-            console.log('✅ [useParticipants] 비디오 파일 FormData에 추가 완료');
+            // ⭐ 웹과 네이티브 플랫폼 구분
+            if (Platform.OS === 'web') {
+              // 웹: File 객체로 변환
+              const response = await fetch(content.video);
+              const blob = await response.blob();
+              const file = new File([blob], fileName, { type: mimeType });
+              formData.append('video', file);
+              console.log(
+                `✅ [useParticipants] 비디오 파일 File 객체로 추가 완료 (${file.size} bytes)`,
+              );
+            } else {
+              // 네이티브: React Native 형식
+              formData.append('video', {
+                uri: content.video,
+                type: mimeType,
+                name: fileName,
+              } as any);
+              console.log('✅ [useParticipants] 비디오 파일 FormData에 추가 완료');
+            }
           } else {
             console.log('  ⏭️  비디오: 이미 업로드된 파일이므로 건너뜀 - ', content.video);
           }

--- a/components/timecapsule-create/components/step-room/hooks/useParticipants.ts
+++ b/components/timecapsule-create/components/step-room/hooks/useParticipants.ts
@@ -9,10 +9,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as ImageManipulator from 'expo-image-manipulator';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Platform } from 'react-native';
-import {
-  fetchMyContent,
-  submitMyContent,
-} from '../../write-bottomsheet/api/content';
+import { fetchMyContent, submitMyContent } from '../../write-bottomsheet/api/content';
 import { getRoomDetail } from '../api/capsule';
 import { DEFAULT_EMOJI, EMPTY_SLOT_EMOJI, PARTICIPANT_STATUS } from '../constants';
 import type { Participant, ParticipantContent, ParticipantStatus } from '../types';
@@ -365,7 +362,9 @@ export function useParticipants({
           // ⭐ has_content 필드로 작성 완료 여부 판단
           const participantStatus = slot.has_content
             ? PARTICIPANT_STATUS.COMPLETED
-            : (slot.status === 'ACCEPTED' ? PARTICIPANT_STATUS.PENDING : PARTICIPANT_STATUS.WAITING);
+            : slot.status === 'ACCEPTED'
+            ? PARTICIPANT_STATUS.PENDING
+            : PARTICIPANT_STATUS.WAITING;
 
           participantsList.push({
             id: slot.user_id,
@@ -393,6 +392,24 @@ export function useParticipants({
         `participantsList.length=${participantsList.length}`,
         `maxParticipants=${maxParticipants}`,
       );
+      // ⭐ 디버깅: 배정된 참가자 상세 확인
+      const assignedParticipants = participantsList.filter((p) => p.name !== '');
+      console.log('🔍 [useParticipants] 배정된 참가자 상세:', {
+        배정된참가자수: assignedParticipants.length,
+        참가자목록: assignedParticipants.map((p) => ({
+          id: p.id,
+          name: p.name,
+          status: p.status,
+          isMe: p.isMe,
+        })),
+        전체슬롯상세: roomDetail.slots.map((slot) => ({
+          slot_number: slot.slot_number,
+          user_id: slot.user_id,
+          nickname: slot.nickname,
+          has_content: slot.has_content,
+          status: slot.status,
+        })),
+      });
 
       // ⭐ 본인이 이미 작성한 경우 콘텐츠 데이터 가져오기 (has_content가 true일 때만)
       const mySlot = roomDetail.slots.find((slot) => slot.user_id === currentUserId);
@@ -431,7 +448,10 @@ export function useParticipants({
             });
           }
         } catch (err: any) {
-          console.error('⚠️ [useParticipants] 본인 콘텐츠 조회 실패 (has_content=true인데 실패):', err);
+          console.error(
+            '⚠️ [useParticipants] 본인 콘텐츠 조회 실패 (has_content=true인데 실패):',
+            err,
+          );
           // 에러가 발생해도 계속 진행 (상태는 COMPLETED 유지)
         }
       } else {
@@ -612,7 +632,9 @@ export function useParticipants({
               const file = new File([blob], fileName, { type: mimeType });
               formData.append('images', file);
               console.log(
-                `✅ [useParticipants] 이미지 ${i + 1}/${content.images.length} File 객체로 추가 완료 (${file.size} bytes)`,
+                `✅ [useParticipants] 이미지 ${i + 1}/${
+                  content.images.length
+                } File 객체로 추가 완료 (${file.size} bytes)`,
               );
             } else {
               // 네이티브: React Native 형식
@@ -622,7 +644,9 @@ export function useParticipants({
                 name: fileName,
               } as any);
               console.log(
-                `✅ [useParticipants] 이미지 ${i + 1}/${content.images.length} FormData에 추가 완료`,
+                `✅ [useParticipants] 이미지 ${i + 1}/${
+                  content.images.length
+                } FormData에 추가 완료`,
               );
             }
           }
@@ -717,8 +741,8 @@ export function useParticipants({
                   ? savedContent.data.text_message
                   : JSON.stringify(savedContent.data.text_message),
               images: savedContent.data.images?.map((img) => img.url) || [],
-              voiceRecording: savedContent.data.music?.url || null,
-              video: savedContent.data.video?.url || null,
+              voiceRecording: savedContent.data.music?.url || undefined,
+              video: savedContent.data.video?.url || undefined,
             };
 
             console.log('✅ [useParticipants] 서버에서 받은 URL로 콘텐츠 업데이트:', {

--- a/components/timecapsule-create/components/step-room/hooks/useParticipants.ts
+++ b/components/timecapsule-create/components/step-room/hooks/useParticipants.ts
@@ -9,7 +9,10 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as ImageManipulator from 'expo-image-manipulator';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Platform } from 'react-native';
-import { fetchMyContent, NotFoundError, submitMyContent } from '../../write-bottomsheet/api/content';
+import {
+  fetchMyContent,
+  submitMyContent,
+} from '../../write-bottomsheet/api/content';
 import { getRoomDetail } from '../api/capsule';
 import { DEFAULT_EMOJI, EMPTY_SLOT_EMOJI, PARTICIPANT_STATUS } from '../constants';
 import type { Participant, ParticipantContent, ParticipantStatus } from '../types';
@@ -235,6 +238,8 @@ interface UseParticipantsReturn {
   saveContent: (participantId: string, content: ParticipantContent) => Promise<void>;
   /** 편집 가능 여부 확인 (본인만) */
   canEdit: (participantId: string) => boolean;
+  /** 참여자 목록 새로고침 */
+  refetchParticipants: () => Promise<void>;
 }
 
 /** useParticipants Hook 파라미터 */
@@ -322,89 +327,92 @@ export function useParticipants({
   // 데이터 가져오기 (목데이터)
   // ============================================
 
-  useEffect(() => {
-    /**
-     * 참여자 목록 가져오기
-     * - capsuleId가 있으면 API 호출
-     * - 없으면 대기 (로딩 상태 유지, 목데이터 사용 안 함)
-     */
-    async function fetchParticipants() {
-      // capsuleId가 없으면 아무것도 하지 않음 (로딩 상태 유지)
-      if (!capsuleId) {
-        // capsuleId가 설정될 때까지 대기 (다음 useEffect 실행에서 처리됨)
-        return;
+  /**
+   * 참여자 목록 가져오기 함수
+   * - capsuleId가 있으면 API 호출
+   * - 없으면 대기 (로딩 상태 유지, 목데이터 사용 안 함)
+   */
+  const fetchParticipants = useCallback(async () => {
+    // capsuleId가 없으면 아무것도 하지 않음 (로딩 상태 유지)
+    if (!capsuleId) {
+      // capsuleId가 설정될 때까지 대기 (다음 useEffect 실행에서 처리됨)
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // ⭐ API 호출: 대기실 상세 조회
+      console.log('🔄 [useParticipants] 참여자 슬롯 정보 조회 시작 - capsuleId:', capsuleId);
+      const roomDetail = await getRoomDetail(capsuleId);
+
+      // 현재 사용자 ID 가져오기 (본인 여부 판단용)
+      const token = await AsyncStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
+      const currentUser = token ? getUserFromToken(token) : null;
+      const currentUserId = currentUser?.id || null;
+
+      // slots[] 배열을 Participant[] 형식으로 변환
+      // ⭐ 수정: roomDetail.slots에는 이미 모든 슬롯(빈 슬롯 포함)이 있으므로 그대로 사용
+      const participantsList: Participant[] = [];
+
+      // 모든 슬롯 변환 (배정된 슬롯 + 빈 슬롯 모두 포함)
+      for (const slot of roomDetail.slots) {
+        if (slot.user_id && slot.nickname) {
+          // 배정된 슬롯
+          const isMe = slot.user_id === currentUserId;
+
+          // ⭐ has_content 필드로 작성 완료 여부 판단
+          const participantStatus = slot.has_content
+            ? PARTICIPANT_STATUS.COMPLETED
+            : (slot.status === 'ACCEPTED' ? PARTICIPANT_STATUS.PENDING : PARTICIPANT_STATUS.WAITING);
+
+          participantsList.push({
+            id: slot.user_id,
+            name: slot.nickname,
+            emoji: DEFAULT_EMOJI, // 기본 이모지 (추후 사용자 프로필에서 가져올 수 있음)
+            status: participantStatus,
+            isHost: slot.is_host,
+            isMe,
+          });
+        } else {
+          // 빈 슬롯 (user_id가 null인 경우)
+          participantsList.push({
+            id: `slot-${slot.slot_number}`,
+            name: '',
+            emoji: EMPTY_SLOT_EMOJI,
+            status: PARTICIPANT_STATUS.WAITING,
+          });
+        }
       }
 
-      setIsLoading(true);
-      setError(null);
+      // ⭐ 디버깅: 슬롯 계산 확인
+      console.log(
+        '🔍 [useParticipants] 슬롯 계산:',
+        `roomDetail.slots.length=${roomDetail.slots.length}`,
+        `participantsList.length=${participantsList.length}`,
+        `maxParticipants=${maxParticipants}`,
+      );
 
-      try {
-        // ⭐ API 호출: 대기실 상세 조회
-        console.log('🔄 [useParticipants] 참여자 슬롯 정보 조회 시작 - capsuleId:', capsuleId);
-        const roomDetail = await getRoomDetail(capsuleId);
-
-        // 현재 사용자 ID 가져오기 (본인 여부 판단용)
-        const token = await AsyncStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
-        const currentUser = token ? getUserFromToken(token) : null;
-        const currentUserId = currentUser?.id || null;
-
-        // slots[] 배열을 Participant[] 형식으로 변환
-        // ⭐ 수정: roomDetail.slots에는 이미 모든 슬롯(빈 슬롯 포함)이 있으므로 그대로 사용
-        const participantsList: Participant[] = [];
-
-        // 모든 슬롯 변환 (배정된 슬롯 + 빈 슬롯 모두 포함)
-        for (const slot of roomDetail.slots) {
-          if (slot.user_id && slot.nickname) {
-            // 배정된 슬롯
-            const isMe = slot.user_id === currentUserId;
-            participantsList.push({
-              id: slot.user_id,
-              name: slot.nickname,
-              emoji: DEFAULT_EMOJI, // 기본 이모지 (추후 사용자 프로필에서 가져올 수 있음)
-              status:
-                slot.status === 'ACCEPTED'
-                  ? PARTICIPANT_STATUS.PENDING
-                  : PARTICIPANT_STATUS.WAITING,
-              isHost: slot.is_host,
-              isMe,
-              // ⭐ 작성 완료 여부는 아래에서 본인 콘텐츠 조회로 확인
-            });
-          } else {
-            // 빈 슬롯 (user_id가 null인 경우)
-            participantsList.push({
-              id: `slot-${slot.slot_number}`,
-              name: '',
-              emoji: EMPTY_SLOT_EMOJI,
-              status: PARTICIPANT_STATUS.WAITING,
-            });
-          }
-        }
-
-        // ⭐ 디버깅: 슬롯 계산 확인
-        console.log(
-          '🔍 [useParticipants] 슬롯 계산:',
-          `roomDetail.slots.length=${roomDetail.slots.length}`,
-          `participantsList.length=${participantsList.length}`,
-          `maxParticipants=${maxParticipants}`,
-        );
-
-        // ⭐ 본인의 콘텐츠 작성 여부 확인
+      // ⭐ 본인이 이미 작성한 경우 콘텐츠 데이터 가져오기 (has_content가 true일 때만)
+      const mySlot = roomDetail.slots.find((slot) => slot.user_id === currentUserId);
+      if (mySlot && mySlot.has_content) {
         try {
-          console.log('🔄 [useParticipants] 본인 콘텐츠 작성 여부 확인 중...');
+          console.log('🔄 [useParticipants] 본인이 작성 완료했으므로 콘텐츠 조회 중...');
           const myContent = await fetchMyContent(capsuleId);
 
-          // 콘텐츠가 존재하면 본인 상태를 COMPLETED로 업데이트 + 콘텐츠 데이터 저장
           if (myContent && myContent.data) {
-            console.log('✅ [useParticipants] 본인이 이미 작성한 콘텐츠 발견!');
+            console.log('✅ [useParticipants] 본인 콘텐츠 조회 성공!');
 
             // API 응답 데이터를 ParticipantContent 형식으로 변환
             const contentData: ParticipantContent = {
-              text: typeof myContent.data.text_message === 'string'
-                ? myContent.data.text_message
-                : JSON.stringify(myContent.data.text_message),
+              text:
+                typeof myContent.data.text_message === 'string'
+                  ? myContent.data.text_message
+                  : JSON.stringify(myContent.data.text_message),
               images: myContent.data.images?.map((img) => img.url) || [],
-              voiceRecording: myContent.data.music?.url || null,
-              video: myContent.data.video?.url || null,
+              voiceRecording: myContent.data.music?.url || undefined,
+              video: myContent.data.video?.url || undefined,
             };
 
             console.log('📦 [useParticipants] 변환된 콘텐츠 데이터:', {
@@ -414,48 +422,38 @@ export function useParticipants({
               hasVideo: !!contentData.video,
             });
 
+            // 본인 참여자에 콘텐츠 데이터 저장
             participantsList.forEach((p) => {
-              if (p.isMe && p.status === PARTICIPANT_STATUS.PENDING) {
-                p.status = PARTICIPANT_STATUS.COMPLETED;
-                p.content = contentData; // ⭐ 서버에서 받은 URL 데이터 저장
-                console.log('✅ [useParticipants] 본인 상태를 COMPLETED로 업데이트 및 콘텐츠 저장:', p.name);
+              if (p.isMe && p.status === PARTICIPANT_STATUS.COMPLETED) {
+                p.content = contentData;
+                console.log('✅ [useParticipants] 본인에게 콘텐츠 데이터 저장:', p.name);
               }
             });
           }
         } catch (err: any) {
-          // 404 에러는 정상 (아직 작성하지 않음)
-          const errorResponse = err?.response || err?.config?.response;
-          const statusCode = errorResponse?.status || err?.statusCode || err?.status;
-          const isNotFoundError =
-            statusCode === 404 ||
-            err instanceof NotFoundError ||
-            err?.name === 'NotFoundError' ||
-            err?.message?.includes('아직 작성하지 않았습니다') ||
-            err?.message?.includes('작성하지 않았습니다') ||
-            err?.message?.includes('CONTENT_NOT_FOUND');
-
-          if (isNotFoundError) {
-            console.log('ℹ️ [useParticipants] 본인이 아직 작성하지 않음 (404) - 정상');
-          } else {
-            console.error('⚠️ [useParticipants] 본인 콘텐츠 조회 실패:', err);
-            // 에러가 발생해도 계속 진행 (상태는 PENDING 유지)
-          }
+          console.error('⚠️ [useParticipants] 본인 콘텐츠 조회 실패 (has_content=true인데 실패):', err);
+          // 에러가 발생해도 계속 진행 (상태는 COMPLETED 유지)
         }
-
-        setParticipants(participantsList);
-        console.log('✅ [useParticipants] 참여자 슬롯 정보 조회 성공:', participantsList);
-      } catch (err) {
-        console.warn('⚠️ [useParticipants] API 호출 실패, 목데이터 사용:', err);
-        setError(err instanceof Error ? err : new Error('API 호출 실패'));
-        // 목데이터로 폴백
-        setParticipants(mockParticipants);
-      } finally {
-        setIsLoading(false);
+      } else {
+        console.log('ℹ️ [useParticipants] 본인이 아직 작성하지 않음 (has_content=false) - 정상');
       }
-    }
 
-    fetchParticipants();
+      setParticipants(participantsList);
+      console.log('✅ [useParticipants] 참여자 슬롯 정보 조회 성공:', participantsList);
+    } catch (err) {
+      console.warn('⚠️ [useParticipants] API 호출 실패, 목데이터 사용:', err);
+      setError(err instanceof Error ? err : new Error('API 호출 실패'));
+      // 목데이터로 폴백
+      setParticipants(mockParticipants);
+    } finally {
+      setIsLoading(false);
+    }
   }, [capsuleId, maxParticipants]);
+
+  // 초기 로드 및 의존성 변경 시 호출
+  useEffect(() => {
+    fetchParticipants();
+  }, [fetchParticipants]);
 
   // ============================================
   // 본인 참여자 정보
@@ -678,9 +676,10 @@ export function useParticipants({
           if (savedContent && savedContent.data) {
             // API 응답 데이터를 ParticipantContent 형식으로 변환
             const contentData: ParticipantContent = {
-              text: typeof savedContent.data.text_message === 'string'
-                ? savedContent.data.text_message
-                : JSON.stringify(savedContent.data.text_message),
+              text:
+                typeof savedContent.data.text_message === 'string'
+                  ? savedContent.data.text_message
+                  : JSON.stringify(savedContent.data.text_message),
               images: savedContent.data.images?.map((img) => img.url) || [],
               voiceRecording: savedContent.data.music?.url || null,
               video: savedContent.data.video?.url || null,
@@ -702,10 +701,14 @@ export function useParticipants({
             );
           } else {
             // 폴백: 로컬 데이터로 업데이트 (웹에서는 blob: URI 만료 문제 있음)
-            console.warn('⚠️ [useParticipants] 서버 콘텐츠 조회 실패, 로컬 데이터 사용 (웹에서 문제 발생 가능)');
+            console.warn(
+              '⚠️ [useParticipants] 서버 콘텐츠 조회 실패, 로컬 데이터 사용 (웹에서 문제 발생 가능)',
+            );
             setParticipants((prev) =>
               prev.map((p) =>
-                p.id === participantId ? { ...p, content, status: PARTICIPANT_STATUS.COMPLETED } : p,
+                p.id === participantId
+                  ? { ...p, content, status: PARTICIPANT_STATUS.COMPLETED }
+                  : p,
               ),
             );
           }
@@ -751,6 +754,20 @@ export function useParticipants({
   );
 
   // ============================================
+  // 참여자 목록 새로고침
+  // ============================================
+
+  /**
+   * 참여자 목록 새로고침
+   * 저장 후 완료 상태를 업데이트하기 위해 사용
+   */
+  const refetchParticipants = useCallback(async () => {
+    console.log('🔄 [useParticipants] 참여자 목록 새로고침 시작...');
+    await fetchParticipants();
+    console.log('✅ [useParticipants] 참여자 목록 새로고침 완료');
+  }, [fetchParticipants]);
+
+  // ============================================
   // 반환
   // ============================================
 
@@ -762,5 +779,6 @@ export function useParticipants({
     updateStatus,
     saveContent,
     canEdit,
+    refetchParticipants,
   };
 }

--- a/components/timecapsule-create/components/step-room/hooks/useRoomData.ts
+++ b/components/timecapsule-create/components/step-room/hooks/useRoomData.ts
@@ -189,7 +189,7 @@ export function useRoomData(orderId?: string, guestCapsuleId?: string): UseRoomD
    *
    * 계산 로직:
    * - 완료 인원: status === 'completed'인 참여자 수
-   * - 전체 인원: 실제 배정된 참여자 수 (빈 슬롯 제외)
+   * - 전체 인원: max_participants (캡슐보관함 API와 동일하게)
    * - 진행률: (완료 인원 / 전체 인원) × 100
    *
    * @param {Participant[]} participants 참여자 목록
@@ -203,11 +203,26 @@ export function useRoomData(orderId?: string, guestCapsuleId?: string): UseRoomD
       // 완료한 참여자 수
       const completed = assignedParticipants.filter((p) => p.status === 'completed').length;
 
-      // 전체 참여자 수 (실제 배정된 인원)
-      const total = assignedParticipants.length;
+      // ⭐ 전체 참여자 수: max_participants 사용 (캡슐보관함 API와 동일)
+      const total = roomSettings?.max_participants || assignedParticipants.length;
 
       // 진행률 계산 (0-100)
       const percentage = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+      // ⭐ 디버깅: 진행률 계산 로그
+      console.log('🔍 [calculateProgress] 진행률 계산:', {
+        전체참가자수: participants.length,
+        배정된참가자수: assignedParticipants.length,
+        maxParticipants: roomSettings?.max_participants,
+        전체인원수: total,
+        완료한참가자수: completed,
+        진행률: percentage,
+        참가자목록: assignedParticipants.map((p) => ({
+          id: p.id,
+          name: p.name,
+          status: p.status,
+        })),
+      });
 
       return {
         completed,

--- a/components/timecapsule-create/components/step-room/hooks/useRoomData.ts
+++ b/components/timecapsule-create/components/step-room/hooks/useRoomData.ts
@@ -225,18 +225,29 @@ export function useRoomData(orderId?: string, guestCapsuleId?: string): UseRoomD
    * 최종 제출 가능 여부 확인
    *
    * 조건:
-   * - 모든 참여자(name이 있는)가 완료 상태인지 확인
-   * - 진행률이 100%일 때만 true
+   * 1. 모든 슬롯이 채워져야 함 (max_participants만큼 참여자 입장)
+   * 2. 모든 참여자가 작성 완료해야 함 (status === 'completed')
    *
    * @param {Participant[]} participants 참여자 목록
    * @returns {boolean} 제출 가능 여부
    */
   const canSubmit = useMemo(() => {
     return (participants: Participant[]): boolean => {
-      const progress = calculateProgress(participants);
-      return progress.percentage === 100;
+      // ⭐ 1. 실제 참여한 인원 (name이 있는 참여자)
+      const assignedParticipants = participants.filter((p) => p.name !== '');
+
+      // ⭐ 2. 모든 슬롯이 채워졌는지 확인 (max_participants와 비교)
+      const maxParticipants = roomSettings?.max_participants || 4;
+      const allSlotsFilled = assignedParticipants.length === maxParticipants;
+
+      // ⭐ 3. 모든 참여자가 작성 완료했는지 확인
+      const allCompleted = assignedParticipants.length > 0 &&
+                          assignedParticipants.every((p) => p.status === 'completed');
+
+      // ⭐ 4. 두 조건 모두 만족해야 제출 가능
+      return allSlotsFilled && allCompleted;
     };
-  }, [calculateProgress]);
+  }, [calculateProgress, roomSettings]);
 
   // ============================================
   // 반환

--- a/components/timecapsule-create/components/step-room/hooks/useRoomData.ts
+++ b/components/timecapsule-create/components/step-room/hooks/useRoomData.ts
@@ -189,7 +189,7 @@ export function useRoomData(orderId?: string, guestCapsuleId?: string): UseRoomD
    *
    * 계산 로직:
    * - 완료 인원: status === 'completed'인 참여자 수
-   * - 전체 인원: max_participants (정원)
+   * - 전체 인원: 실제 배정된 참여자 수 (빈 슬롯 제외)
    * - 진행률: (완료 인원 / 전체 인원) × 100
    *
    * @param {Participant[]} participants 참여자 목록
@@ -197,11 +197,14 @@ export function useRoomData(orderId?: string, guestCapsuleId?: string): UseRoomD
    */
   const calculateProgress = useMemo(() => {
     return (participants: Participant[]): Progress => {
-      // 완료한 참여자 수
-      const completed = participants.filter((p) => p.status === 'completed').length;
+      // ⭐ 실제 배정된 참여자만 필터링 (빈 슬롯 제외: name이 있는 참여자만)
+      const assignedParticipants = participants.filter((p) => p.name !== '');
 
-      // 전체 참여자 수 (max_participants 기준)
-      const total = roomSettings?.max_participants || 0;
+      // 완료한 참여자 수
+      const completed = assignedParticipants.filter((p) => p.status === 'completed').length;
+
+      // 전체 참여자 수 (실제 배정된 인원)
+      const total = assignedParticipants.length;
 
       // 진행률 계산 (0-100)
       const percentage = total > 0 ? Math.round((completed / total) * 100) : 0;

--- a/components/timecapsule-create/components/step-room/index.tsx
+++ b/components/timecapsule-create/components/step-room/index.tsx
@@ -29,11 +29,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-} from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import Icon from 'react-native-remix-icon';
 import SubmitCompleteModal from '../../modals/submit-complete-modal';
 import SubmitConfirmModal from '../../modals/submit-confirm-modal';
@@ -58,7 +54,7 @@ export default function StepRoom({
   orderId: propsOrderId,
   capsuleId: propsCapsuleId,
   inviteCode: propsInviteCode,
-  onSubmit
+  onSubmit,
 }: StepRoomProps) {
   // ============================================
   // Hooks
@@ -81,7 +77,11 @@ export default function StepRoom({
    */
   const TEST_ORDER_ID = '77fd8584-7877-4b70-a720-b7042a355125'; // 백엔드 제공 테스트 orderId
   const initialIsHost = role === 'host';
-  const orderId = propsCapsuleId ? undefined : (initialIsHost ? (propsOrderId || TEST_ORDER_ID) : undefined);
+  const orderId = propsCapsuleId
+    ? undefined
+    : initialIsHost
+    ? propsOrderId || TEST_ORDER_ID
+    : undefined;
 
   /** 캡슐대기실 데이터 Hook - ⭐ 방장: orderId → 게스트: capsuleId */
   const {
@@ -105,6 +105,7 @@ export default function StepRoom({
     error: participantsError,
     saveContent,
     canEdit,
+    refetchParticipants,
   } = useParticipants({
     capsuleId,
     maxParticipants: roomSettings?.max_participants || 4, // roomSettings가 로드되면 올바른 값 사용
@@ -282,10 +283,16 @@ export default function StepRoom({
       hasVoice: !!content.voiceRecording,
       hasVideo: !!content.video,
     });
-    
+
     try {
       await saveContent(selectedParticipant.id, content);
       console.log('✅ [StepRoom] 바텀시트 저장 성공!');
+
+      // ⭐ 저장 성공 후 참여자 목록 새로고침 (다른 참가자들의 완료 상태 업데이트)
+      console.log('🔄 [StepRoom] 참여자 목록 새로고침 시작...');
+      await refetchParticipants();
+      console.log('✅ [StepRoom] 참여자 목록 새로고침 완료');
+
       setIsBottomSheetVisible(false);
     } catch (err) {
       console.error('❌ [StepRoom] 바텀시트 저장 실패:', err);
@@ -302,6 +309,7 @@ export default function StepRoom({
     const isActive = participant.isMe || participant.status === 'completed';
     const showCheckbox = participant.name !== '';
     const isEditable = canEdit(participant.id);
+    const isMyContent = participant.isMe; // 본인의 콘텐츠인지
 
     return (
       <Pressable
@@ -311,12 +319,14 @@ export default function StepRoom({
           isActive ? styles.participantCardActive : styles.participantCardInactive,
         ]}
         onPress={() => {
-          // 프라이버시 체크: 본인 것만 클릭 가능
-          if (participant.name && isEditable) {
-            console.log('📝 [StepRoom] 참여자 카드 클릭:', participant.name);
+          // ⭐ 본인의 콘텐츠만 클릭 가능 (작성 완료 후에도 조회 가능)
+          if (participant.name && isMyContent) {
+            console.log('📝 [StepRoom] 본인 카드 클릭:', participant.name);
+            console.log('  - 상태:', participant.status);
+            console.log('  - 읽기 전용:', participant.status === 'completed');
             setSelectedParticipant(participant);
             setIsBottomSheetVisible(true);
-          } else if (participant.name && !isEditable) {
+          } else if (participant.name && !isMyContent) {
             console.log('🚫 [StepRoom] 다른 사람 카드 클릭 차단:', participant.name);
           }
         }}>
@@ -347,8 +357,9 @@ export default function StepRoom({
                     participant.status === 'pending' && styles.statusPending,
                     participant.status === 'waiting' && styles.statusWaiting,
                   ]}>
+                  {/* ⭐ 본인: 클릭 유도 메시지, 다른 사람: 작성 여부만 표시 */}
                   {participant.status === 'completed' && '작성 완료'}
-                  {participant.status === 'pending' && '클릭하여 작성하기'}
+                  {participant.status === 'pending' && (isMyContent ? '클릭하여 작성하기' : '작성 대기 중')}
                   {participant.status === 'waiting' && '아직 작성하지 않았어요'}
                 </Text>
               </>
@@ -521,12 +532,6 @@ export default function StepRoom({
 
         {/* 하단 정보 */}
         <View style={styles.bottomSection}>
-          <Text style={styles.infoText}>
-            {isHost
-              ? '내 글은 방장이 최종 제출하기 전까지 수정할 수 있어요'
-              : '방장이 최종 제출하기 전까지 수정할 수 있어요'}
-          </Text>
-
           <View style={styles.deadlineContainer}>
             <View style={styles.deadlineContent}>
               <Icon name="time-line" size={16} color={Colors.grey[500]} />
@@ -687,6 +692,7 @@ export default function StepRoom({
             inviteCode={propsInviteCode} // 게스트용 (처음 참여 시 필요)
             onSave={handleBottomSheetSave}
             roomSettings={roomSettings}
+            isReadOnly={selectedParticipant.status === 'completed'}
           />
         )}
       </ScrollView>

--- a/components/timecapsule-create/components/step-room/index.tsx
+++ b/components/timecapsule-create/components/step-room/index.tsx
@@ -316,7 +316,7 @@ export default function StepRoom({
         key={participant.id}
         style={[
           styles.participantCard,
-          isActive ? styles.participantCardActive : styles.participantCardInactive,
+          isMyContent ? styles.participantCardMe : styles.participantCardOther,
         ]}
         onPress={() => {
           // ⭐ 본인의 콘텐츠만 클릭 가능 (작성 완료 후에도 조회 가능)
@@ -333,13 +333,8 @@ export default function StepRoom({
         <View style={styles.participantInfo}>
           {/* 아바타 */}
           <View style={[styles.avatar, isActive && styles.avatarActive]}>
-            <Text
-              style={[
-                styles.avatarEmoji,
-                participant.status === 'waiting' && styles.avatarEmojiDisabled,
-              ]}>
-              {participant.emoji}
-            </Text>
+            {/* TODO: 프로필 이미지 URL 추가 시 Image 컴포넌트로 표시 */}
+            <Icon name="user-line" size={24} color={Colors.grey[400]} />
           </View>
 
           {/* 참여자 정보 */}
@@ -348,7 +343,6 @@ export default function StepRoom({
               <>
                 <View style={styles.participantNameRow}>
                   <Text style={styles.participantName}>{participant.name}</Text>
-                  {participant.isHost && <Text style={styles.crownEmoji}>👑</Text>}
                 </View>
                 <Text
                   style={[
@@ -359,7 +353,8 @@ export default function StepRoom({
                   ]}>
                   {/* ⭐ 본인: 클릭 유도 메시지, 다른 사람: 작성 여부만 표시 */}
                   {participant.status === 'completed' && '작성 완료'}
-                  {participant.status === 'pending' && (isMyContent ? '클릭하여 작성하기' : '작성 대기 중')}
+                  {participant.status === 'pending' &&
+                    (isMyContent ? '클릭하여 작성하기' : '작성 대기 중')}
                   {participant.status === 'waiting' && '아직 작성하지 않았어요'}
                 </Text>
               </>
@@ -373,9 +368,16 @@ export default function StepRoom({
         {participant.name ? (
           showCheckbox && (
             <View
-              style={[styles.checkbox, isActive ? styles.checkboxActive : styles.checkboxInactive]}>
+              style={[
+                styles.checkbox,
+                participant.status === 'completed'
+                  ? styles.checkboxChecked
+                  : isActive
+                  ? styles.checkboxActive
+                  : styles.checkboxInactive,
+              ]}>
               {participant.status === 'completed' && (
-                <Icon name="checkbox-circle-fill" size={20} color={Colors.green[500]} />
+                <Text style={styles.checkboxCheckmark}>✓</Text>
               )}
             </View>
           )

--- a/components/timecapsule-create/components/step-room/index.tsx
+++ b/components/timecapsule-create/components/step-room/index.tsx
@@ -166,7 +166,22 @@ export default function StepRoom({
 
   /** 진행 상황 계산 (완료 인원 / 전체 인원) */
   const progress = useMemo(() => {
-    return calculateProgress(participants);
+    // ⭐ 디버깅: 참가자 목록 확인
+    console.log('🔍 [StepRoom] 진행 상황 계산 - 참가자 목록:', {
+      전체참가자수: participants.length,
+      참가자상세: participants.map((p) => ({
+        id: p.id,
+        name: p.name || '(빈 슬롯)',
+        status: p.status,
+        isMe: p.isMe,
+      })),
+    });
+
+    const result = calculateProgress(participants);
+
+    console.log('🔍 [StepRoom] 진행 상황 계산 결과:', result);
+
+    return result;
   }, [calculateProgress, participants]);
 
   /** 최종 제출 가능 여부 (진행률 100%) */

--- a/components/timecapsule-create/components/step-room/styles.ts
+++ b/components/timecapsule-create/components/step-room/styles.ts
@@ -169,19 +169,17 @@ export const styles = StyleSheet.create({
     backgroundColor: Colors.white[100],
   },
 
-  participantCardActive: {
-    borderColor: Colors.black.darker,
-    shadowColor: Colors.black.darker,
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0,
-    shadowRadius: 6,
-    elevation: 4,
+  participantCardMe: {
+    borderWidth: 1,
+    borderColor: Colors.black[500],
+    borderRadius: 16,
   },
 
-  participantCardInactive: {
+  participantCardOther: {
     backgroundColor: Colors.whiteGrey[200],
     borderRadius: 16,
   },
+
 
   participantInfo: {
     flexDirection: 'row',
@@ -198,19 +196,11 @@ export const styles = StyleSheet.create({
     backgroundColor: Colors.white[100],
     justifyContent: 'center',
     alignItems: 'center',
+    overflow: 'hidden',
   },
 
   avatarActive: {
     borderColor: Colors.lightBlack[500],
-  },
-
-  avatarEmoji: {
-    fontSize: 24,
-  },
-
-  avatarEmojiDisabled: {
-    backgroundColor: Colors.grey[100],
-    borderColor: Colors.whiteGrey[500],
   },
 
   participantDetails: {
@@ -256,12 +246,15 @@ export const styles = StyleSheet.create({
   checkbox: {
     width: 24,
     height: 24,
-    borderRadius: 9999,
+    borderRadius: 12,
+    backgroundColor: Colors.white[50],
     borderWidth: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 
   checkboxActive: {
-    borderColor: Colors.grey[400],
+    borderColor: Colors.darkGrey[500],
   },
 
   checkboxInactive: {
@@ -269,8 +262,18 @@ export const styles = StyleSheet.create({
   },
 
   checkboxChecked: {
-    width: 24,
-    height: 24,
+    backgroundColor: Colors.white[50],
+    borderColor: Colors.darkGrey[500],
+    borderWidth: 1,
+  },
+
+  checkboxCheckmark: {
+    fontFamily: 'Pretendard Variable',
+    fontSize: 14,
+    lineHeight: 14,
+    fontWeight: '700',
+    color: Colors.green[500],
+    includeFontPadding: false,
   },
 
   // 하단 정보 영역

--- a/components/timecapsule-create/components/step-room/types.ts
+++ b/components/timecapsule-create/components/step-room/types.ts
@@ -235,6 +235,8 @@ export interface Slot {
   status: 'ACCEPTED' | 'PENDING';
   /** 참여자 닉네임 (null이면 아직 배정되지 않음) */
   nickname: string | null;
+  /** 콘텐츠 작성 여부 (백엔드 신규 추가) */
+  has_content: boolean;
 }
 
 /** 대기실 상세 조회 API 응답 타입 (GET /api/capsules/step-rooms/:capsuleId) */

--- a/components/timecapsule-create/components/write-bottomsheet/hooks/useMediaPicker.ts
+++ b/components/timecapsule-create/components/write-bottomsheet/hooks/useMediaPicker.ts
@@ -12,9 +12,12 @@
  * - [✓] 권한 처리
  */
 
+import { ALLOWED_EXTENSIONS, MediaType, SIZE_LIMITS } from '@/commons/constants/media';
+import { getFileExtension, validateFileExtension } from '@/utils/mediaType';
+import * as FileSystem from 'expo-file-system/legacy';
 import * as ImagePicker from 'expo-image-picker';
 import { useState } from 'react';
-import { Alert } from 'react-native';
+import { Alert, Platform } from 'react-native';
 import { UseMediaPickerReturn } from '../types';
 
 /**
@@ -44,6 +47,75 @@ export function useMediaPicker(
 
   // 전체 로딩 상태 (하나라도 선택 중이면 true)
   const isPicking = isPickingImage || isPickingVideo || isPickingAudio;
+
+  /**
+   * 파일 크기 확인 (플랫폼별)
+   */
+  const getFileSize = async (uri: string): Promise<number> => {
+    if (Platform.OS === 'web') {
+      try {
+        const response = await fetch(uri);
+        const blob = await response.blob();
+        return blob.size;
+      } catch (error) {
+        console.error('웹에서 파일 크기 가져오기 실패:', error);
+        throw new Error('파일 크기를 확인할 수 없습니다.');
+      }
+    } else {
+      const fileInfo = await FileSystem.getInfoAsync(uri);
+      if (!fileInfo.exists) {
+        throw new Error('파일을 찾을 수 없습니다.');
+      }
+      return 'size' in fileInfo && typeof fileInfo.size === 'number' ? fileInfo.size : 0;
+    }
+  };
+
+  /**
+   * 파일 검증 (타입 및 크기)
+   */
+  const validateMediaFile = async (
+    uri: string,
+    type: MediaType,
+    filename?: string,
+  ): Promise<void> => {
+    // 파일명 추출
+    const extractedFilename = filename || uri.split('/').pop() || '';
+    const extension = getFileExtension(extractedFilename);
+
+    // 확장자 검증
+    if (!validateFileExtension(extractedFilename, type)) {
+      const allowedExtensions = ALLOWED_EXTENSIONS[type];
+      const allowedFormats = allowedExtensions.join(', ').toUpperCase();
+      throw new Error(
+        `${
+          type === 'IMAGE' ? '이미지' : type === 'VIDEO' ? '동영상' : '음성'
+        } 파일은 ${allowedFormats} 형식만 업로드 가능합니다.\n선택한 파일: ${
+          extractedFilename || '알 수 없음'
+        }`,
+      );
+    }
+
+    // 파일 크기 검증
+    try {
+      const fileSize = await getFileSize(uri);
+      const sizeLimit = SIZE_LIMITS[type];
+      const sizeLimitMB = sizeLimit / (1024 * 1024);
+
+      if (fileSize > sizeLimit) {
+        const fileSizeMB = (fileSize / (1024 * 1024)).toFixed(2);
+        throw new Error(
+          `파일 크기가 너무 큽니다.\n${
+            type === 'IMAGE' ? '이미지' : type === 'VIDEO' ? '동영상' : '음성'
+          } 파일은 ${sizeLimitMB}MB 이하여야 합니다.\n현재 파일 크기: ${fileSizeMB}MB`,
+        );
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('크기가 너무 큽니다')) {
+        throw error;
+      }
+      throw new Error('파일 크기를 확인할 수 없습니다.');
+    }
+  };
 
   /**
    * 이미지 선택 함수
@@ -87,10 +159,14 @@ export function useMediaPicker(
 
       if (!result.canceled && result.assets && result.assets.length > 0) {
         // 선택된 이미지 URI 추출
-        const selectedUris = result.assets.map((asset) => asset.uri);
+        const selectedUris: string[] = [];
+        const validatedAssets = result.assets.map((asset) => ({
+          uri: asset.uri,
+          filename: asset.fileName || asset.uri.split('/').pop() || '',
+        }));
 
         // 최대 개수 재확인
-        if (currentPhotosCount + selectedUris.length > maxImagesPerPerson) {
+        if (currentPhotosCount + validatedAssets.length > maxImagesPerPerson) {
           Alert.alert(
             '알림',
             `사진은 최대 ${maxImagesPerPerson}개까지 추가할 수 있습니다.\n현재 ${currentPhotosCount}개 선택됨`,
@@ -98,8 +174,23 @@ export function useMediaPicker(
           return;
         }
 
-        // 콜백 호출
-        onImagesPicked(selectedUris);
+        // 각 파일 검증 (타입 및 크기)
+        for (const asset of validatedAssets) {
+          try {
+            await validateMediaFile(asset.uri, 'IMAGE', asset.filename);
+            selectedUris.push(asset.uri);
+          } catch (validationError) {
+            const errorMessage =
+              validationError instanceof Error ? validationError.message : '파일 검증 실패';
+            Alert.alert('파일 검증 실패', `${asset.filename}\n${errorMessage}`);
+            // 검증 실패한 파일은 제외하고 계속 진행
+          }
+        }
+
+        // 검증 통과한 파일만 콜백 호출
+        if (selectedUris.length > 0) {
+          onImagesPicked(selectedUris);
+        }
       }
     } catch (err) {
       const errorMessage =
@@ -171,8 +262,19 @@ export function useMediaPicker(
     });
 
     if (!result.canceled && result.assets && result.assets.length > 0) {
-      const videoUri = result.assets[0].uri;
-      onVideoPicked(videoUri);
+      const asset = result.assets[0];
+      const videoUri = asset.uri;
+      const filename = asset.fileName || videoUri.split('/').pop() || '';
+
+      try {
+        // 파일 검증 (타입 및 크기)
+        await validateMediaFile(videoUri, 'VIDEO', filename);
+        onVideoPicked(videoUri);
+      } catch (validationError) {
+        const errorMessage =
+          validationError instanceof Error ? validationError.message : '파일 검증 실패';
+        Alert.alert('파일 검증 실패', `${filename}\n${errorMessage}`);
+      }
     }
   };
 

--- a/components/timecapsule-create/components/write-bottomsheet/hooks/useMediaPicker.ts
+++ b/components/timecapsule-create/components/write-bottomsheet/hooks/useMediaPicker.ts
@@ -54,11 +54,19 @@ export function useMediaPicker(
   const getFileSize = async (uri: string): Promise<number> => {
     if (Platform.OS === 'web') {
       try {
+        console.log(`🔍 [getFileSize] 웹에서 파일 크기 확인 중: ${uri.substring(0, 50)}...`);
         const response = await fetch(uri);
+        if (!response.ok) {
+          throw new Error(`fetch 실패: ${response.status} ${response.statusText}`);
+        }
         const blob = await response.blob();
+        console.log(`✅ [getFileSize] 파일 크기: ${blob.size} bytes`);
         return blob.size;
       } catch (error) {
-        console.error('웹에서 파일 크기 가져오기 실패:', error);
+        console.error('❌ [getFileSize] 웹에서 파일 크기 가져오기 실패:', error);
+        if (error instanceof TypeError) {
+          console.error('  TypeError: CORS 또는 네트워크 문제일 수 있습니다');
+        }
         throw new Error('파일 크기를 확인할 수 없습니다.');
       }
     } else {
@@ -113,6 +121,13 @@ export function useMediaPicker(
       if (error instanceof Error && error.message.includes('크기가 너무 큽니다')) {
         throw error;
       }
+      // ⭐ 웹 환경에서 파일 크기 확인 실패 시 경고만 하고 계속 진행
+      if (Platform.OS === 'web') {
+        console.warn(
+          `⚠️ [validateMediaFile] 웹에서 파일 크기 검증 실패, 계속 진행: ${extractedFilename}`,
+        );
+        return; // 검증 실패해도 계속 진행
+      }
       throw new Error('파일 크기를 확인할 수 없습니다.');
     }
   };
@@ -158,12 +173,19 @@ export function useMediaPicker(
       });
 
       if (!result.canceled && result.assets && result.assets.length > 0) {
+        console.log(`🔍 [pickImage] 이미지 선택 완료: ${result.assets.length}개`);
+
         // 선택된 이미지 URI 추출
         const selectedUris: string[] = [];
         const validatedAssets = result.assets.map((asset) => ({
           uri: asset.uri,
           filename: asset.fileName || asset.uri.split('/').pop() || '',
         }));
+
+        console.log(
+          '📝 [pickImage] 선택된 파일:',
+          validatedAssets.map((a) => `${a.filename} (${a.uri.substring(0, 50)}...)`),
+        );
 
         // 최대 개수 재확인
         if (currentPhotosCount + validatedAssets.length > maxImagesPerPerson) {
@@ -177,11 +199,14 @@ export function useMediaPicker(
         // 각 파일 검증 (타입 및 크기)
         for (const asset of validatedAssets) {
           try {
+            console.log(`🔍 [pickImage] 파일 검증 중: ${asset.filename}`);
             await validateMediaFile(asset.uri, 'IMAGE', asset.filename);
             selectedUris.push(asset.uri);
+            console.log(`✅ [pickImage] 파일 검증 성공: ${asset.filename}`);
           } catch (validationError) {
             const errorMessage =
               validationError instanceof Error ? validationError.message : '파일 검증 실패';
+            console.error(`❌ [pickImage] 파일 검증 실패: ${asset.filename} - ${errorMessage}`);
             Alert.alert('파일 검증 실패', `${asset.filename}\n${errorMessage}`);
             // 검증 실패한 파일은 제외하고 계속 진행
           }
@@ -189,7 +214,10 @@ export function useMediaPicker(
 
         // 검증 통과한 파일만 콜백 호출
         if (selectedUris.length > 0) {
+          console.log(`✅ [pickImage] 총 ${selectedUris.length}개 파일 콜백 호출`);
           onImagesPicked(selectedUris);
+        } else {
+          console.warn('⚠️ [pickImage] 검증 통과한 파일이 없습니다');
         }
       }
     } catch (err) {
@@ -266,13 +294,19 @@ export function useMediaPicker(
       const videoUri = asset.uri;
       const filename = asset.fileName || videoUri.split('/').pop() || '';
 
+      console.log(`🔍 [pickVideo] 비디오 선택 완료: ${filename}`);
+      console.log(`  URI: ${videoUri.substring(0, 80)}...`);
+
       try {
         // 파일 검증 (타입 및 크기)
+        console.log(`🔍 [pickVideo] 파일 검증 중: ${filename}`);
         await validateMediaFile(videoUri, 'VIDEO', filename);
+        console.log(`✅ [pickVideo] 파일 검증 성공: ${filename}`);
         onVideoPicked(videoUri);
       } catch (validationError) {
         const errorMessage =
           validationError instanceof Error ? validationError.message : '파일 검증 실패';
+        console.error(`❌ [pickVideo] 파일 검증 실패: ${filename} - ${errorMessage}`);
         Alert.alert('파일 검증 실패', `${filename}\n${errorMessage}`);
       }
     }

--- a/components/timecapsule-create/components/write-bottomsheet/hooks/useSubmitContent.ts
+++ b/components/timecapsule-create/components/write-bottomsheet/hooks/useSubmitContent.ts
@@ -91,6 +91,13 @@ async function validateMediaFile(uri: string, type: MediaType, filename?: string
     if (error instanceof Error && error.message.includes('크기가 너무 큽니다')) {
       throw error;
     }
+    // ⭐ 웹 환경에서 파일 크기 확인 실패 시 경고만 하고 계속 진행
+    if (Platform.OS === 'web') {
+      console.warn(
+        `⚠️ [validateMediaFile] 웹에서 파일 크기 검증 실패, 계속 진행: ${extractedFilename}`,
+      );
+      return; // 검증 실패해도 계속 진행
+    }
     throw new Error('파일 크기를 확인할 수 없습니다.');
   }
 }
@@ -118,19 +125,39 @@ async function uriToFile(uri: string, name: string, type: string): Promise<File>
   try {
     if (Platform.OS === 'web') {
       // 웹 환경: fetch를 사용하여 Blob으로 변환
-      const response = await fetch(uri);
-      if (!response.ok) {
-        throw new Error(`파일을 가져올 수 없습니다: ${response.status} ${response.statusText}`);
+      console.log(`🔄 [uriToFile] 웹 환경에서 파일 변환 시작: ${uri.substring(0, 50)}...`);
+
+      try {
+        const response = await fetch(uri);
+        if (!response.ok) {
+          throw new Error(`파일을 가져올 수 없습니다: ${response.status} ${response.statusText}`);
+        }
+        const blob = await response.blob();
+        console.log(`✅ [uriToFile] Blob 생성 완료: ${blob.size} bytes, type: ${blob.type || type}`);
+
+        // Blob의 타입이 비어있으면 전달받은 타입 사용
+        const finalType = blob.type || type;
+        const file = new File([blob], name, { type: finalType });
+        console.log(`✅ [uriToFile] File 객체 생성 완료: ${file.name}, ${file.size} bytes`);
+        return file;
+      } catch (fetchError) {
+        console.error('❌ [uriToFile] fetch 실패, 원인:', fetchError);
+        // fetch 실패 시 추가 정보 로깅
+        if (fetchError instanceof TypeError) {
+          console.error('  TypeError 발생 - CORS 또는 네트워크 문제일 수 있습니다');
+        }
+        throw fetchError;
       }
-      const blob = await response.blob();
-      return new File([blob], name, { type });
     } else {
       // 네이티브 환경: 기존 방식 사용
       const blob = await uriToBlob(uri);
       return new File([blob], name, { type });
     }
   } catch (error) {
-    console.error('URI to File 변환 실패:', error);
+    console.error('❌ [uriToFile] URI to File 변환 실패:', error);
+    console.error('  URI:', uri);
+    console.error('  파일명:', name);
+    console.error('  타입:', type);
     if (error instanceof Error) {
       throw new Error(`파일 변환에 실패했습니다: ${error.message}`);
     }
@@ -243,16 +270,20 @@ export function useSubmitContent(): UseSubmitContentReturn {
       // 새 이미지 파일 추가
       if (newImageUris.length > 0) {
         setUploadProgress(`이미지 ${newImageUris.length}개 업로드 중...`);
+        console.log(`📤 [useSubmitContent] 새 이미지 ${newImageUris.length}개 업로드 준비`);
         for (let i = 0; i < newImageUris.length; i++) {
           const photoUri = newImageUris[i];
           console.log(`  🔄 이미지 ${i + 1}: 로컬 파일 검증 및 변환 중...`);
+          console.log(`    URI: ${photoUri.substring(0, 80)}...`);
 
           // 파일명 추출
           const filename = photoUri.split('/').pop() || generateFileName(photoUri, 'photo', 'jpg');
+          console.log(`    파일명: ${filename}`);
 
           // 파일 검증 (타입 및 크기)
           try {
             await validateMediaFile(photoUri, 'IMAGE', filename);
+            console.log(`    ✅ 파일 검증 성공`);
           } catch (validationError) {
             const errorMessage =
               validationError instanceof Error ? validationError.message : '파일 검증 실패';
@@ -271,8 +302,14 @@ export function useSubmitContent(): UseSubmitContentReturn {
               ? 'image/webp'
               : 'image/jpeg';
 
+          console.log(`    MIME 타입: ${mimeType}, 확장자: ${extension}`);
+
           const fileName = generateFileName(photoUri, 'photo', extension || 'jpg');
+          console.log(`    생성된 파일명: ${fileName}`);
+
           const photoFile = await uriToFile(photoUri, fileName, mimeType);
+          console.log(`    File 객체 생성 완료: ${photoFile.size} bytes`);
+
           formData.append('images', photoFile);
           console.log(
             `✅ [useSubmitContent] 이미지 ${i + 1}/${newImageUris.length} 변환 완료: ${fileName}`,
@@ -286,10 +323,12 @@ export function useSubmitContent(): UseSubmitContentReturn {
           // 로컬 파일: 새로 업로드
           setUploadProgress('음악 파일 업로드 중...');
           console.log('📤 [useSubmitContent] 음악 파일 검증 및 변환 중...');
+          console.log(`  URI: ${data.music.substring(0, 80)}...`);
 
           // 파일명 추출
           const filename =
             data.music.split('/').pop() || generateFileName(data.music, 'music', 'mp3');
+          console.log(`  파일명: ${filename}`);
 
           // 파일 검증 (타입 및 크기)
           try {
@@ -314,8 +353,14 @@ export function useSubmitContent(): UseSubmitContentReturn {
               ? 'audio/mp4'
               : 'audio/mpeg';
 
+          console.log(`  MIME 타입: ${mimeType}, 확장자: ${extension}`);
+
           const fileName = generateFileName(data.music, 'music', extension || 'mp3');
+          console.log(`  생성된 파일명: ${fileName}`);
+
           const musicFile = await uriToFile(data.music, fileName, mimeType);
+          console.log(`  File 객체 생성 완료: ${musicFile.size} bytes`);
+
           formData.append('music', musicFile);
           console.log(`✅ [useSubmitContent] 음악 파일 변환 완료: ${fileName}`);
         } else {
@@ -331,10 +376,12 @@ export function useSubmitContent(): UseSubmitContentReturn {
           // 로컬 파일: 새로 업로드
           setUploadProgress('비디오 파일 업로드 중...');
           console.log('📤 [useSubmitContent] 비디오 파일 검증 및 변환 중...');
+          console.log(`  URI: ${data.video.substring(0, 80)}...`);
 
           // 파일명 추출
           const filename =
             data.video.split('/').pop() || generateFileName(data.video, 'video', 'mp4');
+          console.log(`  파일명: ${filename}`);
 
           // 파일 검증 (타입 및 크기)
           try {
@@ -351,8 +398,14 @@ export function useSubmitContent(): UseSubmitContentReturn {
           const mimeType =
             extension === 'mp4' ? 'video/mp4' : extension === 'webm' ? 'video/webm' : 'video/mp4';
 
+          console.log(`  MIME 타입: ${mimeType}, 확장자: ${extension}`);
+
           const fileName = generateFileName(data.video, 'video', extension || 'mp4');
+          console.log(`  생성된 파일명: ${fileName}`);
+
           const videoFile = await uriToFile(data.video, fileName, mimeType);
+          console.log(`  File 객체 생성 완료: ${videoFile.size} bytes`);
+
           formData.append('video', videoFile);
           console.log(`✅ [useSubmitContent] 비디오 파일 변환 완료: ${fileName}`);
         } else {
@@ -364,6 +417,21 @@ export function useSubmitContent(): UseSubmitContentReturn {
 
       console.log('📤 [useSubmitContent] API 제출 시작');
       setUploadProgress('서버에 전송 중...');
+
+      // ⭐ FormData 내용 확인 (디버깅용)
+      if (Platform.OS === 'web') {
+        console.log('📋 [useSubmitContent] FormData 내용 확인:');
+        for (const pair of (formData as any).entries()) {
+          const [key, value] = pair;
+          if (value instanceof File) {
+            console.log(`  ${key}: File(${value.name}, ${value.size} bytes, ${value.type})`);
+          } else if (value instanceof Blob) {
+            console.log(`  ${key}: Blob(${value.size} bytes, ${value.type})`);
+          } else {
+            console.log(`  ${key}: ${typeof value === 'string' ? value.substring(0, 50) : value}`);
+          }
+        }
+      }
 
       // 3. API 호출
       const result = await submitMyContent(capsuleId, formData);

--- a/components/timecapsule-create/components/write-bottomsheet/hooks/useSubmitContent.ts
+++ b/components/timecapsule-create/components/write-bottomsheet/hooks/useSubmitContent.ts
@@ -4,19 +4,139 @@
  *
  * 체크리스트:
  * - [✓] validateContent 함수 구현
- * - [✓] React Native FormData 형식으로 파일 추가 ({ uri, type, name })
+ * - [✓] uriToFile 헬퍼 함수 구현
+ * - [✓] createFormData 함수 구현
  * - [✓] 실제 API 연동 submitContent 함수 구현
  * - [✓] 로딩 상태 관리 (isSubmitting)
  * - [✓] 에러 상태 관리 (error)
- * - [✓] 업로드 진행 상태 관리 (uploadProgress)
  * - [✓] capsuleId 파라미터 추가
  * - [✓] text_message 필수 검증
  */
 
+import { ALLOWED_EXTENSIONS, MediaType, SIZE_LIMITS } from '@/commons/constants/media';
+import { getFileExtension, validateFileExtension } from '@/utils/mediaType';
+import * as FileSystem from 'expo-file-system/legacy';
 import { useState } from 'react';
 import { Platform } from 'react-native';
 import { submitMyContent } from '../api/content';
 import type { UserContentFormData, UseSubmitContentReturn, ValidationResult } from '../types';
+
+/**
+ * URI가 로컬 파일인지 확인 (HTTP/HTTPS URL이 아닌지)
+ * @param uri 파일 URI
+ * @returns 로컬 파일이면 true, HTTP URL이면 false
+ */
+function isLocalFile(uri: string): boolean {
+  return !uri.startsWith('http://') && !uri.startsWith('https://');
+}
+
+/**
+ * 파일 크기 확인 (플랫폼별)
+ */
+async function getFileSize(uri: string): Promise<number> {
+  if (Platform.OS === 'web') {
+    try {
+      const response = await fetch(uri);
+      const blob = await response.blob();
+      return blob.size;
+    } catch (error) {
+      console.error('웹에서 파일 크기 가져오기 실패:', error);
+      throw new Error('파일 크기를 확인할 수 없습니다.');
+    }
+  } else {
+    const fileInfo = await FileSystem.getInfoAsync(uri);
+    if (!fileInfo.exists) {
+      throw new Error('파일을 찾을 수 없습니다.');
+    }
+    return 'size' in fileInfo && typeof fileInfo.size === 'number' ? fileInfo.size : 0;
+  }
+}
+
+/**
+ * 파일 검증 (타입 및 크기)
+ */
+async function validateMediaFile(uri: string, type: MediaType, filename?: string): Promise<void> {
+  // 파일명 추출
+  const extractedFilename = filename || uri.split('/').pop() || '';
+  const extension = getFileExtension(extractedFilename);
+
+  // 확장자 검증
+  if (!validateFileExtension(extractedFilename, type)) {
+    const allowedExtensions = ALLOWED_EXTENSIONS[type];
+    const allowedFormats = allowedExtensions.join(', ').toUpperCase();
+    throw new Error(
+      `${
+        type === 'IMAGE' ? '이미지' : type === 'VIDEO' ? '동영상' : '음성'
+      } 파일은 ${allowedFormats} 형식만 업로드 가능합니다.\n선택한 파일: ${
+        extractedFilename || '알 수 없음'
+      }`,
+    );
+  }
+
+  // 파일 크기 검증
+  try {
+    const fileSize = await getFileSize(uri);
+    const sizeLimit = SIZE_LIMITS[type];
+    const sizeLimitMB = sizeLimit / (1024 * 1024);
+
+    if (fileSize > sizeLimit) {
+      const fileSizeMB = (fileSize / (1024 * 1024)).toFixed(2);
+      throw new Error(
+        `파일 크기가 너무 큽니다.\n${
+          type === 'IMAGE' ? '이미지' : type === 'VIDEO' ? '동영상' : '음성'
+        } 파일은 ${sizeLimitMB}MB 이하여야 합니다.\n현재 파일 크기: ${fileSizeMB}MB`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('크기가 너무 큽니다')) {
+      throw error;
+    }
+    throw new Error('파일 크기를 확인할 수 없습니다.');
+  }
+}
+
+/**
+ * URI를 Blob으로 변환하는 헬퍼 함수
+ */
+async function uriToBlob(uri: string): Promise<Blob> {
+  const response = await fetch(uri);
+  const blob = await response.blob();
+  return blob;
+}
+
+/**
+ * URI를 File 객체로 변환하는 헬퍼 함수
+ * React Native 환경에서 URI를 File/Blob 객체로 변환
+ * 웹 환경에서는 File API를 직접 사용
+ *
+ * @param uri - 파일 URI
+ * @param name - 파일명
+ * @param type - MIME 타입
+ * @returns File 객체
+ */
+async function uriToFile(uri: string, name: string, type: string): Promise<File> {
+  try {
+    if (Platform.OS === 'web') {
+      // 웹 환경: fetch를 사용하여 Blob으로 변환
+      const response = await fetch(uri);
+      if (!response.ok) {
+        throw new Error(`파일을 가져올 수 없습니다: ${response.status} ${response.statusText}`);
+      }
+      const blob = await response.blob();
+      return new File([blob], name, { type });
+    } else {
+      // 네이티브 환경: 기존 방식 사용
+      const blob = await uriToBlob(uri);
+      return new File([blob], name, { type });
+    }
+  } catch (error) {
+    console.error('URI to File 변환 실패:', error);
+    if (error instanceof Error) {
+      throw new Error(`파일 변환에 실패했습니다: ${error.message}`);
+    }
+    throw new Error('파일 변환에 실패했습니다');
+  }
+}
 
 /**
  * 파일명 생성 헬퍼 함수
@@ -30,28 +150,6 @@ function generateFileName(uri: string, prefix: string, extension: string): strin
   }
 
   return `${prefix}_${timestamp}.${extension}`;
-}
-
-/**
- * URI가 로컬 파일인지 확인 (HTTP/HTTPS URL이 아닌지)
- * @param uri 파일 URI
- * @returns 로컬 파일이면 true, HTTP URL이면 false
- */
-function isLocalFile(uri: string): boolean {
-  return !uri.startsWith('http://') && !uri.startsWith('https://');
-}
-
-/**
- * 웹 환경에서 URI를 Blob으로 변환
- * @param uri 파일 URI
- * @returns Blob 객체
- */
-async function uriToBlob(uri: string): Promise<Blob> {
-  const response = await fetch(uri);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch file: ${response.statusText}`);
-  }
-  return await response.blob();
 }
 
 /**
@@ -104,126 +202,174 @@ export function useSubmitContent(): UseSubmitContentReturn {
         throw new Error(validation.message);
       }
 
-      setUploadProgress('파일 준비 중...');
       console.log('📤 [useSubmitContent] FormData 생성 시작');
+      setUploadProgress('FormData 생성 중...');
 
       // 2. FormData 생성
+      // React Native FormData는 웹과 네이티브 모두에서 작동합니다
       const formData = new FormData();
 
       // text_message 추가 (필수!)
       formData.append('text_message', data.textContent.trim());
 
-      // invite_code 추가 (선택사항)
-      if (data.inviteCode && data.inviteCode.trim().length > 0) {
-        formData.append('invite_code', data.inviteCode.trim());
-        console.log('📤 [useSubmitContent] 초대 코드 추가:', data.inviteCode.trim());
-      }
+      // ⭐ 이미 업로드된 파일 URL 분리
+      const existingImageUrls: string[] = [];
+      const newImageUris: string[] = [];
 
-      // 이미지 파일 추가
       if (data.photos.length > 0) {
-        setUploadProgress(`이미지 ${data.photos.length}개 추가 중...`);
-        console.log(`📤 [useSubmitContent] 이미지 ${data.photos.length}개 추가 중...`);
+        console.log(`📤 [useSubmitContent] 이미지 ${data.photos.length}개 처리 중...`);
         for (let i = 0; i < data.photos.length; i++) {
           const photoUri = data.photos[i];
 
-          // ⭐ HTTP/HTTPS URL은 이미 업로드된 파일이므로 제외
-          if (!isLocalFile(photoUri)) {
-            console.log(`  ⏭️  이미지 ${i + 1}: 이미 업로드된 파일이므로 건너뜀 - ${photoUri}`);
-            continue;
-          }
-
-          const fileName = generateFileName(photoUri, 'photo', 'jpg');
-
-          // ⭐ 플랫폼별 분기 처리
-          if (Platform.OS === 'web') {
-            // 웹: URI를 Blob으로 변환 후 추가
-            const blob = await uriToBlob(photoUri);
-            formData.append('images', blob, fileName);
-            console.log(
-              `✅ [useSubmitContent] [웹] 이미지 ${i + 1}/${
-                data.photos.length
-              } 추가 완료: ${fileName}`,
-            );
+          if (isLocalFile(photoUri)) {
+            // 로컬 파일: 새로 업로드
+            newImageUris.push(photoUri);
           } else {
-            // React Native: { uri, type, name } 형태로 추가
-            formData.append('images', {
-              uri: photoUri,
-              type: 'image/jpeg',
-              name: fileName,
-            } as any);
-            console.log(
-              `✅ [useSubmitContent] [앱] 이미지 ${i + 1}/${
-                data.photos.length
-              } 추가 완료: ${fileName}`,
-            );
+            // HTTP/HTTPS URL: 이미 업로드된 파일
+            existingImageUrls.push(photoUri);
+            console.log(`  ⏭️  이미지 ${i + 1}: 이미 업로드된 파일 URL 저장 - ${photoUri}`);
           }
         }
       }
 
-      // 음악 파일 추가
+      // ⭐ 이미 업로드된 이미지 URL을 별도 필드로 전송 (백엔드가 기존 파일 유지)
+      if (existingImageUrls.length > 0) {
+        console.log(`📤 [useSubmitContent] 기존 이미지 URL ${existingImageUrls.length}개 전송`);
+        existingImageUrls.forEach((url, index) => {
+          formData.append(`existing_image_urls[${index}]`, url);
+        });
+      }
+
+      // 새 이미지 파일 추가
+      if (newImageUris.length > 0) {
+        setUploadProgress(`이미지 ${newImageUris.length}개 업로드 중...`);
+        for (let i = 0; i < newImageUris.length; i++) {
+          const photoUri = newImageUris[i];
+          console.log(`  🔄 이미지 ${i + 1}: 로컬 파일 검증 및 변환 중...`);
+
+          // 파일명 추출
+          const filename = photoUri.split('/').pop() || generateFileName(photoUri, 'photo', 'jpg');
+
+          // 파일 검증 (타입 및 크기)
+          try {
+            await validateMediaFile(photoUri, 'IMAGE', filename);
+          } catch (validationError) {
+            const errorMessage =
+              validationError instanceof Error ? validationError.message : '파일 검증 실패';
+            console.error(`  ❌ 이미지 ${i + 1} 검증 실패:`, errorMessage);
+            throw new Error(`이미지 ${i + 1} 검증 실패: ${errorMessage}`);
+          }
+
+          // MIME 타입 추론
+          const extension = getFileExtension(filename);
+          const mimeType =
+            extension === 'jpg' || extension === 'jpeg'
+              ? 'image/jpeg'
+              : extension === 'png'
+              ? 'image/png'
+              : extension === 'webp'
+              ? 'image/webp'
+              : 'image/jpeg';
+
+          const fileName = generateFileName(photoUri, 'photo', extension || 'jpg');
+          const photoFile = await uriToFile(photoUri, fileName, mimeType);
+          formData.append('images', photoFile);
+          console.log(
+            `✅ [useSubmitContent] 이미지 ${i + 1}/${newImageUris.length} 변환 완료: ${fileName}`,
+          );
+        }
+      }
+
+      // 음악 파일 처리
       if (data.music) {
-        // ⭐ HTTP/HTTPS URL은 이미 업로드된 파일이므로 제외
         if (isLocalFile(data.music)) {
-          setUploadProgress('음악 파일 추가 중...');
-          console.log('📤 [useSubmitContent] 음악 파일 추가 중...');
-          const fileName = generateFileName(data.music, 'music', 'mp3');
+          // 로컬 파일: 새로 업로드
+          setUploadProgress('음악 파일 업로드 중...');
+          console.log('📤 [useSubmitContent] 음악 파일 검증 및 변환 중...');
 
-          // ⭐ 플랫폼별 분기 처리
-          if (Platform.OS === 'web') {
-            // 웹: URI를 Blob으로 변환 후 추가
-            const blob = await uriToBlob(data.music);
-            formData.append('music', blob, fileName);
-            console.log(`✅ [useSubmitContent] [웹] 음악 파일 추가 완료: ${fileName}`);
-          } else {
-            // React Native: { uri, type, name } 형태로 추가
-            formData.append('music', {
-              uri: data.music,
-              type: 'audio/mpeg',
-              name: fileName,
-            } as any);
-            console.log(`✅ [useSubmitContent] [앱] 음악 파일 추가 완료: ${fileName}`);
+          // 파일명 추출
+          const filename =
+            data.music.split('/').pop() || generateFileName(data.music, 'music', 'mp3');
+
+          // 파일 검증 (타입 및 크기)
+          try {
+            await validateMediaFile(data.music, 'AUDIO', filename);
+          } catch (validationError) {
+            const errorMessage =
+              validationError instanceof Error ? validationError.message : '파일 검증 실패';
+            console.error('  ❌ 음악 파일 검증 실패:', errorMessage);
+            throw new Error(`음악 파일 검증 실패: ${errorMessage}`);
           }
+
+          // MIME 타입 추론
+          const extension = getFileExtension(filename);
+          const mimeType =
+            extension === 'mp3' || extension === 'mpeg'
+              ? 'audio/mpeg'
+              : extension === 'm4a' || extension === 'x-m4a'
+              ? 'audio/x-m4a'
+              : extension === 'aac' || extension === 'x-aac'
+              ? 'audio/aac'
+              : extension === 'mp4'
+              ? 'audio/mp4'
+              : 'audio/mpeg';
+
+          const fileName = generateFileName(data.music, 'music', extension || 'mp3');
+          const musicFile = await uriToFile(data.music, fileName, mimeType);
+          formData.append('music', musicFile);
+          console.log(`✅ [useSubmitContent] 음악 파일 변환 완료: ${fileName}`);
         } else {
-          console.log('  ⏭️  음악: 이미 업로드된 파일이므로 건너뜀 - ', data.music);
+          // HTTP/HTTPS URL: 이미 업로드된 파일
+          console.log('  ⏭️  음악: 이미 업로드된 파일 URL 전송 - ', data.music);
+          formData.append('existing_music_url', data.music);
         }
       }
 
-      // 비디오 파일 추가
+      // 비디오 파일 처리
       if (data.video) {
-        // ⭐ HTTP/HTTPS URL은 이미 업로드된 파일이므로 제외
         if (isLocalFile(data.video)) {
-          setUploadProgress('비디오 파일 추가 중...');
-          console.log('📤 [useSubmitContent] 비디오 파일 추가 중...');
-          const fileName = generateFileName(data.video, 'video', 'mp4');
+          // 로컬 파일: 새로 업로드
+          setUploadProgress('비디오 파일 업로드 중...');
+          console.log('📤 [useSubmitContent] 비디오 파일 검증 및 변환 중...');
 
-          // ⭐ 플랫폼별 분기 처리
-          if (Platform.OS === 'web') {
-            // 웹: URI를 Blob으로 변환 후 추가
-            const blob = await uriToBlob(data.video);
-            formData.append('video', blob, fileName);
-            console.log(`✅ [useSubmitContent] [웹] 비디오 파일 추가 완료: ${fileName}`);
-          } else {
-            // React Native: { uri, type, name } 형태로 추가
-            formData.append('video', {
-              uri: data.video,
-              type: 'video/mp4',
-              name: fileName,
-            } as any);
-            console.log(`✅ [useSubmitContent] [앱] 비디오 파일 추가 완료: ${fileName}`);
+          // 파일명 추출
+          const filename =
+            data.video.split('/').pop() || generateFileName(data.video, 'video', 'mp4');
+
+          // 파일 검증 (타입 및 크기)
+          try {
+            await validateMediaFile(data.video, 'VIDEO', filename);
+          } catch (validationError) {
+            const errorMessage =
+              validationError instanceof Error ? validationError.message : '파일 검증 실패';
+            console.error('  ❌ 비디오 파일 검증 실패:', errorMessage);
+            throw new Error(`비디오 파일 검증 실패: ${errorMessage}`);
           }
+
+          // MIME 타입 추론
+          const extension = getFileExtension(filename);
+          const mimeType =
+            extension === 'mp4' ? 'video/mp4' : extension === 'webm' ? 'video/webm' : 'video/mp4';
+
+          const fileName = generateFileName(data.video, 'video', extension || 'mp4');
+          const videoFile = await uriToFile(data.video, fileName, mimeType);
+          formData.append('video', videoFile);
+          console.log(`✅ [useSubmitContent] 비디오 파일 변환 완료: ${fileName}`);
         } else {
-          console.log('  ⏭️  비디오: 이미 업로드된 파일이므로 건너뜀 - ', data.video);
+          // HTTP/HTTPS URL: 이미 업로드된 파일
+          console.log('  ⏭️  비디오: 이미 업로드된 파일 URL 전송 - ', data.video);
+          formData.append('existing_video_url', data.video);
         }
       }
 
-      setUploadProgress('저장 중...');
       console.log('📤 [useSubmitContent] API 제출 시작');
+      setUploadProgress('서버에 전송 중...');
 
       // 3. API 호출
       const result = await submitMyContent(capsuleId, formData);
 
-      setUploadProgress('');
       console.log('✅ [useSubmitContent] 제출 완료:', result);
+      setUploadProgress('');
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : '제출에 실패했습니다.';
       console.error('❌ [useSubmitContent] 제출 실패:', errorMessage);

--- a/components/timecapsule-create/components/write-bottomsheet/index.tsx
+++ b/components/timecapsule-create/components/write-bottomsheet/index.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/commons/components/button';
 import { DualButton } from '@/commons/components/dual-button';
 import { useModal } from '@/commons/components/modal/hooks/useModal';
 import { Colors } from '@/commons/constants';
+import { AudioAttachment } from '@/components/shared/audio-attachment';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Alert, Image, Pressable, Text, TextInput, View } from 'react-native';
@@ -33,6 +34,7 @@ export default function UserBottomSheet({
   inviteCode,
   onSave,
   roomSettings,
+  isReadOnly = false,
 }: UserBottomSheetProps) {
   // 모달 제어 Hook
   const { openModal, closeModal } = useModal();
@@ -42,6 +44,12 @@ export default function UserBottomSheet({
 
   // ⭐ API 로딩 상태
   const [isLoadingContent, setIsLoadingContent] = React.useState(false);
+
+  // ⭐ AudioAttachment 모달 상태
+  const [isAudioAttachmentVisible, setIsAudioAttachmentVisible] = React.useState(false);
+
+  // ⭐ 콘텐츠 제출 완료 여부 (서버 status 기반)
+  const [hasSubmitted, setHasSubmitted] = React.useState(false);
 
   // react-hook-form 설정
   const {
@@ -77,9 +85,10 @@ export default function UserBottomSheet({
 
         if (myContent && myContent.data) {
           console.log('✅ [UserBottomSheet] 서버에서 콘텐츠 불러오기 성공');
-          const textContent = typeof myContent.data.text_message === 'string'
-            ? myContent.data.text_message
-            : JSON.stringify(myContent.data.text_message);
+          const textContent =
+            typeof myContent.data.text_message === 'string'
+              ? myContent.data.text_message
+              : JSON.stringify(myContent.data.text_message);
 
           reset({
             textContent,
@@ -87,6 +96,14 @@ export default function UserBottomSheet({
             music: myContent.data.music?.url || null,
             video: myContent.data.video?.url || null,
           });
+
+          // ⭐ 서버 status가 COMPLETED이면 이미 제출 완료 상태로 설정
+          if (myContent.data.status === 'COMPLETED') {
+            console.log('ℹ️ [UserBottomSheet] 이미 제출 완료된 콘텐츠입니다.');
+            setHasSubmitted(true);
+          } else {
+            setHasSubmitted(false);
+          }
         }
       } catch (err: any) {
         // 404는 정상 (아직 작성 안 함)
@@ -101,44 +118,26 @@ export default function UserBottomSheet({
 
         if (isNotFoundError) {
           console.log('ℹ️ [UserBottomSheet] 아직 작성하지 않음 (404) - 빈 폼 표시');
-          // participant.content 폴백 사용
-          if (participant?.content) {
-            console.log('🔄 [UserBottomSheet] participant.content 폴백 사용');
-            reset({
-              textContent: participant.content.text || '',
-              photos: participant.content.images || [],
-              music: participant.content.voiceRecording || null,
-              video: participant.content.video || null,
-            });
-          } else {
-            // 새로 작성하는 경우 빈 값으로 초기화
-            console.log('📝 [UserBottomSheet] 새로운 콘텐츠 작성');
-            reset({
-              textContent: '',
-              photos: [],
-              music: null,
-              video: null,
-            });
-          }
+          setHasSubmitted(false); // ⭐ 아직 제출 안 함
+          // participant.content 폴백 사용 안 함 - 서버가 소스 오브 트루스
+          console.log('📝 [UserBottomSheet] 새로운 콘텐츠 작성 (서버에 데이터 없음)');
+          reset({
+            textContent: '',
+            photos: [],
+            music: null,
+            video: null,
+          });
         } else {
           console.error('❌ [UserBottomSheet] 콘텐츠 불러오기 실패:', err);
-          // 에러 발생 시 participant.content 폴백
-          if (participant?.content) {
-            console.log('🔄 [UserBottomSheet] 에러 발생, participant.content 폴백 사용');
-            reset({
-              textContent: participant.content.text || '',
-              photos: participant.content.images || [],
-              music: participant.content.voiceRecording || null,
-              video: participant.content.video || null,
-            });
-          } else {
-            reset({
-              textContent: '',
-              photos: [],
-              music: null,
-              video: null,
-            });
-          }
+          // 에러 발생 시에도 빈 폼으로 초기화 (서버를 신뢰)
+          console.log('⚠️ [UserBottomSheet] 에러 발생, 빈 폼으로 초기화');
+          setHasSubmitted(false);
+          reset({
+            textContent: '',
+            photos: [],
+            music: null,
+            video: null,
+          });
         }
       } finally {
         setIsLoadingContent(false);
@@ -158,26 +157,23 @@ export default function UserBottomSheet({
   const hasMusic = roomSettings?.has_music ?? false;
   const hasVideo = roomSettings?.has_video ?? false;
 
-  // useMediaPicker Hook 사용
-  const { pickImage, pickVideo, pickAudio, isPickingImage, isPickingVideo, isPickingAudio, error } =
-    useMediaPicker(
-      // 이미지 선택 완료 콜백
-      (uris: string[]) => {
-        setValue('photos', [...currentPhotos, ...uris], { shouldDirty: true });
-      },
-      // 비디오 선택 완료 콜백
-      (uri: string) => {
-        setValue('video', uri, { shouldDirty: true });
-      },
-      // 오디오 선택 완료 콜백
-      (uri: string) => {
-        setValue('music', uri, { shouldDirty: true });
-      },
-      currentPhotos.length,
-      !!currentVideo,
-      !!currentMusic,
-      maxImagesPerPerson, // ⭐ 추가
-    );
+  // useMediaPicker Hook 사용 (오디오 제외)
+  const { pickImage, pickVideo, isPickingImage, isPickingVideo, error } = useMediaPicker(
+    // 이미지 선택 완료 콜백
+    (uris: string[]) => {
+      setValue('photos', [...currentPhotos, ...uris], { shouldDirty: true });
+    },
+    // 비디오 선택 완료 콜백
+    (uri: string) => {
+      setValue('video', uri, { shouldDirty: true });
+    },
+    // 오디오 선택 완료 콜백 (사용하지 않음 - AudioAttachment로 대체)
+    () => {},
+    currentPhotos.length,
+    !!currentVideo,
+    !!currentMusic,
+    maxImagesPerPerson, // ⭐ 추가
+  );
 
   // useSubmitContent Hook 사용
   const {
@@ -207,9 +203,29 @@ export default function UserBottomSheet({
     pickVideo();
   };
 
-  // 음악 추가 핸들러
+  // 음악 추가 핸들러 - AudioAttachment 모달 열기
   const handleAddMusic = () => {
-    pickAudio();
+    // 이미 음악이 있으면 교체 확인
+    if (currentMusic) {
+      Alert.alert('음악 교체', '이미 음악이 있습니다. 교체하시겠습니까?', [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '교체',
+          onPress: () => {
+            setIsAudioAttachmentVisible(true);
+          },
+        },
+      ]);
+      return;
+    }
+
+    setIsAudioAttachmentVisible(true);
+  };
+
+  // AudioAttachment에서 음악 선택 완료 콜백
+  const handleAudioSelected = (uri: string, name: string) => {
+    setValue('music', uri, { shouldDirty: true });
+    setIsAudioAttachmentVisible(false);
   };
 
   // 에러 발생 시 알림 표시
@@ -228,6 +244,13 @@ export default function UserBottomSheet({
 
   // 폼 제출 핸들러
   const onFormSubmit = async (data: UserContentFormData) => {
+    // ⭐ 이미 제출 완료된 경우 저장 방지
+    if (hasSubmitted || isReadOnly) {
+      console.log('⚠️ [UserBottomSheet] 이미 제출 완료된 콘텐츠입니다. 저장 불가.');
+      Alert.alert('저장 불가', '이미 제출 완료된 콘텐츠는 수정할 수 없습니다.');
+      return;
+    }
+
     // ⭐ 연타 방지: 이미 저장 중이면 즉시 무시
     if (isSaving || isSubmitting) {
       console.log('⚠️ [UserBottomSheet] 이미 저장 중입니다. 무시됨.');
@@ -277,6 +300,8 @@ export default function UserBottomSheet({
 
       // 제출 성공 시 모달 표시 후 바텀시트 닫기
       console.log('🎉 [UserBottomSheet] 저장 성공!');
+      // ⭐ 저장 성공 시 제출 완료 상태로 설정 (영구적으로 재수정 불가)
+      setHasSubmitted(true);
       openModal({
         width: 344,
         height: 'auto',
@@ -289,7 +314,8 @@ export default function UserBottomSheet({
             </View>
 
             {/* 타이틀 */}
-            <Text style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
+            <Text
+              style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
               저장 완료
             </Text>
 
@@ -301,7 +327,7 @@ export default function UserBottomSheet({
                 marginBottom: 24,
                 textAlign: 'center',
               }}>
-              타임캡슐 내용이 저장되었습니다!{'\n'}나중에도 수정할 수 있어요
+              타임캡슐 내용이 저장되었습니다!
             </Text>
 
             {/* 확인 버튼 */}
@@ -344,7 +370,8 @@ export default function UserBottomSheet({
             </View>
 
             {/* 타이틀 */}
-            <Text style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
+            <Text
+              style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
               저장 실패
             </Text>
 
@@ -360,21 +387,44 @@ export default function UserBottomSheet({
             </Text>
 
             {/* 확인 버튼 */}
-            <Button
-              label="확인"
-              variant="primary"
-              size="S"
-              fullWidth={true}
-              onPress={closeModal}
-            />
+            <Button label="확인" variant="primary" size="S" fullWidth={true} onPress={closeModal} />
           </View>
         ),
       });
     }
   };
 
-  // 저장 버튼 핸들러
-  const handleSave = handleSubmit(onFormSubmit);
+  // react-hook-form의 handleSubmit 함수 저장
+  const handleFormSubmit = handleSubmit(onFormSubmit);
+
+  // 저장 버튼 핸들러 (확인 모달 먼저 표시)
+  const handleSave = () => {
+    // ⭐ 이미 제출 완료된 경우 또는 읽기 전용 모드인 경우 저장 불가
+    if (hasSubmitted || isReadOnly) {
+      Alert.alert('저장 불가', '이미 제출 완료된 콘텐츠는 수정할 수 없습니다.');
+      return;
+    }
+
+    // 저장 확인 Alert 표시 (BottomSheet 위에서도 보이도록)
+    Alert.alert(
+      '저장하시겠어요?',
+      '한번 저장한 내용은 수정할 수 없어요',
+      [
+        {
+          text: '취소',
+          style: 'cancel',
+        },
+        {
+          text: '저장하기',
+          style: 'default',
+          onPress: () => {
+            handleFormSubmit();
+          },
+        },
+      ],
+      { cancelable: true }
+    );
+  };
 
   // 취소 버튼 핸들러
   const handleCancel = () => {
@@ -391,21 +441,34 @@ export default function UserBottomSheet({
   // 하단 고정 버튼 영역 (공통 컴포넌트의 footer 스타일 사용)
   const renderFooter = () => (
     <>
-      <DualButton
-        cancelLabel="취소"
-        confirmLabel={
-          isSaving || isSubmitting
-            ? (uploadProgress || '저장 중...') // ⭐ 업로드 진행 상태 표시
-            : '저장'
-        }
-        size="M"
-        cancelVariant="outline"
-        confirmVariant="primary"
-        confirmDisabled={isSaving || isSubmitting} // ⭐ 로컬 상태도 체크
-        onCancelPress={handleCancel}
-        onConfirmPress={handleSave}
-      />
-      <Text style={styles.hintText}>나중에도 수정할 수 있어요</Text>
+      {!isReadOnly && !hasSubmitted ? (
+        <>
+          <DualButton
+            cancelLabel="취소"
+            confirmLabel={
+              isSaving || isSubmitting
+                ? uploadProgress || '저장 중...' // ⭐ 업로드 진행 상태 표시
+                : '저장'
+            }
+            size="M"
+            cancelVariant="outline"
+            confirmVariant="primary"
+            confirmDisabled={isSaving || isSubmitting || hasSubmitted} // ⭐ 제출 완료 시에도 비활성화
+            onCancelPress={handleCancel}
+            onConfirmPress={handleSave}
+          />
+          <Text style={styles.hintText}>한번 저장한 내용은 수정할 수 없어요</Text>
+        </>
+      ) : (
+        <View style={{ paddingHorizontal: 20, paddingVertical: 16 }}>
+          <Button label="닫기" variant="outline" size="M" fullWidth={true} onPress={onClose} />
+          {hasSubmitted && !isReadOnly && (
+            <Text style={[styles.hintText, { marginTop: 8, textAlign: 'center' }]}>
+              이미 제출 완료된 콘텐츠입니다
+            </Text>
+          )}
+        </View>
+      )}
     </>
   );
 
@@ -415,16 +478,17 @@ export default function UserBottomSheet({
         {/* 헤더 */}
         <View style={styles.header}>
           <Text style={styles.title}>MY CONTENTS</Text>
-          <Text style={styles.subtitle}>나만의 타임캡슐 내용을 작성해요</Text>
+          <Text style={styles.subtitle}>
+            {hasSubmitted || isReadOnly
+              ? '제출 완료된 콘텐츠입니다 (수정 불가)'
+              : '나만의 타임캡슐 내용을 작성해요'}
+          </Text>
         </View>
 
         {/* 텍스트 섹션 */}
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
-            <Image
-              source={{ uri: 'http://localhost:3845/assets/text-icon.svg' }}
-              style={styles.sectionIcon}
-            />
+            <Icon name="file-text-line" size={20} color={Colors.black[500]} />
             <Text style={styles.sectionTitle}>텍스트</Text>
           </View>
           <View style={styles.textAreaContainer}>
@@ -436,13 +500,21 @@ export default function UserBottomSheet({
               }}
               render={({ field: { onChange, value } }) => (
                 <TextInput
-                  style={styles.textArea}
+                  style={[
+                    styles.textArea,
+                    (isReadOnly || hasSubmitted) && {
+                      backgroundColor: Colors.grey[50],
+                      color: Colors.black[500],
+                      borderRadius: 16, // ⭐ 컨테이너와 동일한 borderRadius 적용
+                    },
+                  ]}
                   placeholder="당신의 이야기를 남겨주세요..."
                   placeholderTextColor={Colors.grey[400]}
                   multiline
                   value={value}
                   onChangeText={onChange}
                   textAlignVertical="top"
+                  editable={!isReadOnly && !hasSubmitted}
                 />
               )}
             />
@@ -452,22 +524,22 @@ export default function UserBottomSheet({
         {/* 사진 섹션 */}
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
-            <Image
-              source={{ uri: 'http://localhost:3845/assets/image-icon.svg' }}
-              style={styles.sectionIcon}
-            />
+            <Icon name="image-line" size={20} color={Colors.black[500]} />
             <Text style={styles.sectionTitle}>
               사진 ({watch('photos').length}/{maxImagesPerPerson})
             </Text>
           </View>
-          <Button
-            label={isPickingImage ? '선택 중...' : '사진 추가'}
-            variant="outline"
-            size="M"
-            icon="ri-add-line"
-            disabled={isPickingImage || currentPhotos.length >= maxImagesPerPerson}
-            onPress={handleAddPhoto}
-          />
+          {/* ⭐ 읽기 전용 모드가 아닐 때만 사진 추가 버튼 표시 */}
+          {!isReadOnly && !hasSubmitted && (
+            <Button
+              label={isPickingImage ? '선택 중...' : '사진 추가'}
+              variant="outline"
+              size="M"
+              icon="ri-add-line"
+              disabled={isPickingImage || currentPhotos.length >= maxImagesPerPerson}
+              onPress={handleAddPhoto}
+            />
+          )}
 
           {/* 추가된 사진 미리보기 - 그리드 배치 (3 + 2) */}
           <Controller
@@ -497,11 +569,13 @@ export default function UserBottomSheet({
                           </Text>
                         </View>
                         {/* 삭제 버튼 */}
-                        <Pressable
-                          style={styles.deleteButton}
-                          onPress={() => handleDeletePhoto(index)}>
-                          <Icon name="ri-close-line" size={20} color={Colors.black[500]} />
-                        </Pressable>
+                        {!isReadOnly && !hasSubmitted && (
+                          <Pressable
+                            style={styles.deleteButton}
+                            onPress={() => handleDeletePhoto(index)}>
+                            <Icon name="close-line" size={20} color={Colors.black[500]} />
+                          </Pressable>
+                        )}
                       </View>
                     ))}
                   </View>
@@ -515,38 +589,37 @@ export default function UserBottomSheet({
         {hasMusic && (
           <View style={styles.section}>
             <View style={styles.sectionHeader}>
-              <Image
-                source={{ uri: 'http://localhost:3845/assets/music-icon.svg' }}
-                style={styles.sectionIcon}
-              />
+              <Icon name="music-line" size={20} color={Colors.black[500]} />
               <Text style={styles.sectionTitle}>음악 ({currentMusic ? 1 : 0}/1)</Text>
             </View>
-            <Button
-              label={isPickingAudio ? '선택 중...' : currentMusic ? '음악 교체' : '음악 추가'}
-              variant="outline"
-              size="M"
-              icon="ri-add-line"
-              disabled={isPickingAudio}
-              onPress={handleAddMusic}
-            />
+            {/* ⭐ 읽기 전용 모드가 아닐 때만 음악 추가/교체 버튼 표시 */}
+            {!isReadOnly && !hasSubmitted && (
+              <Button
+                label={currentMusic ? '음악 교체' : '음악 추가'}
+                variant="outline"
+                size="M"
+                icon="ri-add-line"
+                disabled={isAudioAttachmentVisible}
+                onPress={handleAddMusic}
+              />
+            )}
 
             {/* 선택된 음악 표시 */}
             {currentMusic && (
               <View style={styles.mediaFileContainer}>
                 <View style={styles.mediaFileInfo}>
-                  <Image
-                    source={{ uri: 'http://localhost:3845/assets/music-icon.svg' }}
-                    style={styles.mediaFileIcon}
-                  />
+                  <Icon name="music-fill" size={24} color={Colors.black[500]} />
                   <Text style={styles.mediaFileName} numberOfLines={1}>
                     {currentMusic.split('/').pop() || '음악 파일'}
                   </Text>
                 </View>
-                <Pressable
-                  style={styles.mediaDeleteButton}
-                  onPress={() => setValue('music', null, { shouldDirty: true })}>
-                  <Icon name="ri-close-line" size={20} color={Colors.black[500]} />
-                </Pressable>
+                {!isReadOnly && !hasSubmitted && (
+                  <Pressable
+                    style={styles.mediaDeleteButton}
+                    onPress={() => setValue('music', null, { shouldDirty: true })}>
+                    <Icon name="close-line" size={20} color={Colors.black[500]} />
+                  </Pressable>
+                )}
               </View>
             )}
           </View>
@@ -556,43 +629,49 @@ export default function UserBottomSheet({
         {hasVideo && (
           <View style={styles.section}>
             <View style={styles.sectionHeader}>
-              <Image
-                source={{ uri: 'http://localhost:3845/assets/video-icon.svg' }}
-                style={styles.sectionIcon}
-              />
+              <Icon name="video-line" size={20} color={Colors.black[500]} />
               <Text style={styles.sectionTitle}>동영상 ({currentVideo ? 1 : 0}/1)</Text>
             </View>
-            <Button
-              label={isPickingVideo ? '선택 중...' : currentVideo ? '동영상 교체' : '동영상 추가'}
-              variant="outline"
-              size="M"
-              icon="ri-add-line"
-              disabled={isPickingVideo}
-              onPress={handleAddVideo}
-            />
+            {/* ⭐ 읽기 전용 모드가 아닐 때만 동영상 추가/교체 버튼 표시 */}
+            {!isReadOnly && !hasSubmitted && (
+              <Button
+                label={isPickingVideo ? '선택 중...' : currentVideo ? '동영상 교체' : '동영상 추가'}
+                variant="outline"
+                size="M"
+                icon="ri-add-line"
+                disabled={isPickingVideo}
+                onPress={handleAddVideo}
+              />
+            )}
 
             {/* 선택된 동영상 표시 */}
             {currentVideo && (
               <View style={styles.mediaFileContainer}>
                 <View style={styles.mediaFileInfo}>
-                  <Image
-                    source={{ uri: 'http://localhost:3845/assets/video-icon.svg' }}
-                    style={styles.mediaFileIcon}
-                  />
+                  <Icon name="video-fill" size={24} color={Colors.black[500]} />
                   <Text style={styles.mediaFileName} numberOfLines={1}>
                     {currentVideo.split('/').pop() || '동영상 파일'}
                   </Text>
                 </View>
-                <Pressable
-                  style={styles.mediaDeleteButton}
-                  onPress={() => setValue('video', null, { shouldDirty: true })}>
-                  <Icon name="ri-close-line" size={20} color={Colors.black[500]} />
-                </Pressable>
+                {!isReadOnly && !hasSubmitted && (
+                  <Pressable
+                    style={styles.mediaDeleteButton}
+                    onPress={() => setValue('video', null, { shouldDirty: true })}>
+                    <Icon name="close-line" size={20} color={Colors.black[500]} />
+                  </Pressable>
+                )}
               </View>
             )}
           </View>
         )}
       </View>
+
+      {/* AudioAttachment 모달 */}
+      <AudioAttachment
+        visible={isAudioAttachmentVisible}
+        onClose={() => setIsAudioAttachmentVisible(false)}
+        onSelectAudio={handleAudioSelected}
+      />
     </BottomSheet>
   );
 }

--- a/components/timecapsule-create/components/write-bottomsheet/index.tsx
+++ b/components/timecapsule-create/components/write-bottomsheet/index.tsx
@@ -219,9 +219,9 @@ export default function UserBottomSheet({
     pickVideo();
   };
 
-  // 음악 추가 핸들러 - AudioAttachment 모달 열기
+  // 음성 추가 핸들러 - AudioAttachment 모달 열기
   const handleAddMusic = () => {
-    // 이미 음악이 있으면 교체 확인
+    // 이미 음성이 있으면 교체 확인
     if (currentMusic) {
       openModal({
         width: 344,
@@ -237,7 +237,7 @@ export default function UserBottomSheet({
             {/* 타이틀 */}
             <Text
               style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
-              음악 교체
+              음성 교체
             </Text>
 
             {/* 설명 */}
@@ -248,7 +248,7 @@ export default function UserBottomSheet({
                 marginBottom: 24,
                 textAlign: 'center',
               }}>
-              이미 음악이 있습니다. 교체하시겠습니까?
+              이미 음성이 있습니다. 교체하시겠습니까?
             </Text>
 
             {/* 버튼 */}
@@ -274,7 +274,7 @@ export default function UserBottomSheet({
     setIsAudioAttachmentVisible(true);
   };
 
-  // AudioAttachment에서 음악 선택 완료 콜백
+  // AudioAttachment에서 음성 선택 완료 콜백
   const handleAudioSelected = (uri: string, name: string) => {
     setValue('music', uri, { shouldDirty: true });
     setIsAudioAttachmentVisible(false);
@@ -495,7 +495,7 @@ export default function UserBottomSheet({
         console.log('  📝 제출 데이터 요약:');
         console.log('    - 텍스트:', data.textContent.trim().substring(0, 30) + '...');
         console.log('    - 이미지:', data.photos.length, '개');
-        console.log('    - 음악:', data.music ? '있음' : '없음');
+        console.log('    - 음성:', data.music ? '있음' : '없음');
         console.log('    - 비디오:', data.video ? '있음' : '없음');
         await submitContent({ ...data, inviteCode }, capsuleId);
       }
@@ -654,8 +654,7 @@ export default function UserBottomSheet({
           </View>
 
           {/* 타이틀 */}
-          <Text
-            style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
+          <Text style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
             저장하시겠어요?
           </Text>
 
@@ -764,8 +763,8 @@ export default function UserBottomSheet({
           <Text style={styles.hintText}>한번 저장한 내용은 수정할 수 없어요</Text>
         </>
       ) : (
-        <View style={{ paddingHorizontal: 20, paddingVertical: 16 }}>
-          <Button label="닫기" variant="outline" size="M" fullWidth={true} onPress={onClose} />
+        <View style={{ paddingVertical: 16 }}>
+          <Button label="닫기" variant="primary" size="L" fullWidth={true} onPress={onClose} />
           {hasSubmitted && !isReadOnly && (
             <Text style={[styles.hintText, { marginTop: 8, textAlign: 'center' }]}>
               이미 제출 완료된 콘텐츠입니다
@@ -889,17 +888,17 @@ export default function UserBottomSheet({
           />
         </View>
 
-        {/* 음악 섹션 - hasMusic이 true일 때만 표시 */}
+        {/* 음성 섹션 - hasMusic이 true일 때만 표시 */}
         {hasMusic && (
           <View style={styles.section}>
             <View style={styles.sectionHeader}>
               <Icon name="music-line" size={20} color={Colors.black[500]} />
-              <Text style={styles.sectionTitle}>음악 ({currentMusic ? 1 : 0}/1)</Text>
+              <Text style={styles.sectionTitle}>음성 ({currentMusic ? 1 : 0}/1)</Text>
             </View>
-            {/* ⭐ 읽기 전용 모드가 아닐 때만 음악 추가/교체 버튼 표시 */}
+            {/* ⭐ 읽기 전용 모드가 아닐 때만 음성 추가/교체 버튼 표시 */}
             {!isReadOnly && !hasSubmitted && (
               <Button
-                label={currentMusic ? '음악 교체' : '음악 추가'}
+                label={currentMusic ? '음성 교체' : '음성 추가'}
                 variant="outline"
                 size="M"
                 icon="ri-add-line"
@@ -908,13 +907,13 @@ export default function UserBottomSheet({
               />
             )}
 
-            {/* 선택된 음악 표시 */}
+            {/* 선택된 음성 표시 */}
             {currentMusic && (
               <View style={styles.mediaFileContainer}>
                 <View style={styles.mediaFileInfo}>
                   <Icon name="music-fill" size={24} color={Colors.black[500]} />
                   <Text style={styles.mediaFileName} numberOfLines={1}>
-                    {currentMusic.split('/').pop() || '음악 파일'}
+                    {currentMusic.split('/').pop() || '음성 파일'}
                   </Text>
                 </View>
                 {!isReadOnly && !hasSubmitted && (

--- a/components/timecapsule-create/components/write-bottomsheet/index.tsx
+++ b/components/timecapsule-create/components/write-bottomsheet/index.tsx
@@ -20,7 +20,7 @@ import { Colors } from '@/commons/constants';
 import { AudioAttachment } from '@/components/shared/audio-attachment';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Alert, Image, Pressable, Text, TextInput, View } from 'react-native';
+import { Image, Pressable, Text, TextInput, View } from 'react-native';
 import Icon from 'react-native-remix-icon';
 import { useMediaPicker, useSubmitContent } from './hooks';
 import { styles } from './styles';
@@ -51,6 +51,9 @@ export default function UserBottomSheet({
   // ⭐ 콘텐츠 제출 완료 여부 (서버 status 기반)
   const [hasSubmitted, setHasSubmitted] = React.useState(false);
 
+  // ⭐ 이미 한 번 콘텐츠를 불러왔는지 여부 (캡슐 ID별로 추적)
+  const hasLoadedRef = React.useRef<string | null>(null);
+
   // react-hook-form 설정
   const {
     control,
@@ -69,10 +72,16 @@ export default function UserBottomSheet({
     },
   });
 
-  // ⭐ 바텀시트가 열릴 때 서버에서 최신 콘텐츠 불러오기
+  // ⭐ 바텀시트가 열릴 때 서버에서 최신 콘텐츠 불러오기 (한 번만)
   React.useEffect(() => {
     async function loadContent() {
       if (!isVisible || !capsuleId) {
+        return;
+      }
+
+      // ⭐ 이미 이 캡슐의 콘텐츠를 불러왔다면 건너뛰기 (404 방지)
+      if (hasLoadedRef.current === capsuleId) {
+        console.log('ℹ️ [UserBottomSheet] 이미 불러온 콘텐츠 - API 호출 건너뜀');
         return;
       }
 
@@ -104,6 +113,9 @@ export default function UserBottomSheet({
           } else {
             setHasSubmitted(false);
           }
+
+          // ⭐ 불러오기 완료 표시
+          hasLoadedRef.current = capsuleId;
         }
       } catch (err: any) {
         // 404는 정상 (아직 작성 안 함)
@@ -127,6 +139,9 @@ export default function UserBottomSheet({
             music: null,
             video: null,
           });
+
+          // ⭐ 404도 불러오기 시도 완료로 표시 (다음에 다시 시도 안 함)
+          hasLoadedRef.current = capsuleId;
         } else {
           console.error('❌ [UserBottomSheet] 콘텐츠 불러오기 실패:', err);
           // 에러 발생 시에도 빈 폼으로 초기화 (서버를 신뢰)
@@ -138,6 +153,7 @@ export default function UserBottomSheet({
             music: null,
             video: null,
           });
+          // ⭐ 에러 발생 시에는 다음에 다시 시도할 수 있도록 hasLoadedRef 업데이트 안 함
         }
       } finally {
         setIsLoadingContent(false);
@@ -207,15 +223,51 @@ export default function UserBottomSheet({
   const handleAddMusic = () => {
     // 이미 음악이 있으면 교체 확인
     if (currentMusic) {
-      Alert.alert('음악 교체', '이미 음악이 있습니다. 교체하시겠습니까?', [
-        { text: '취소', style: 'cancel' },
-        {
-          text: '교체',
-          onPress: () => {
-            setIsAudioAttachmentVisible(true);
-          },
-        },
-      ]);
+      openModal({
+        width: 344,
+        height: 'auto',
+        closeOnBackdropPress: true,
+        children: (
+          <View style={{ padding: 24, alignItems: 'center' }}>
+            {/* 아이콘 */}
+            <View style={{ marginBottom: 16 }}>
+              <Icon name="question-line" size={64} color={Colors.blue[500]} />
+            </View>
+
+            {/* 타이틀 */}
+            <Text
+              style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
+              음악 교체
+            </Text>
+
+            {/* 설명 */}
+            <Text
+              style={{
+                fontSize: 14,
+                color: Colors.grey[600],
+                marginBottom: 24,
+                textAlign: 'center',
+              }}>
+              이미 음악이 있습니다. 교체하시겠습니까?
+            </Text>
+
+            {/* 버튼 */}
+            <DualButton
+              cancelLabel="취소"
+              confirmLabel="교체"
+              size="S"
+              cancelVariant="outline"
+              confirmVariant="primary"
+              fullWidth={true}
+              onCancelPress={closeModal}
+              onConfirmPress={() => {
+                closeModal();
+                setIsAudioAttachmentVisible(true);
+              }}
+            />
+          </View>
+        ),
+      });
       return;
     }
 
@@ -231,9 +283,41 @@ export default function UserBottomSheet({
   // 에러 발생 시 알림 표시
   React.useEffect(() => {
     if (error) {
-      Alert.alert('오류', error);
+      openModal({
+        width: 344,
+        height: 'auto',
+        closeOnBackdropPress: true,
+        children: (
+          <View style={{ padding: 24, alignItems: 'center' }}>
+            {/* 에러 아이콘 */}
+            <View style={{ marginBottom: 16 }}>
+              <Icon name="error-warning-fill" size={64} color={Colors.red[500]} />
+            </View>
+
+            {/* 타이틀 */}
+            <Text
+              style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
+              오류
+            </Text>
+
+            {/* 에러 메시지 */}
+            <Text
+              style={{
+                fontSize: 14,
+                color: Colors.grey[600],
+                marginBottom: 24,
+                textAlign: 'center',
+              }}>
+              {error}
+            </Text>
+
+            {/* 확인 버튼 */}
+            <Button label="확인" variant="primary" size="S" fullWidth={true} onPress={closeModal} />
+          </View>
+        ),
+      });
     }
-  }, [error]);
+  }, [error, openModal, closeModal]);
 
   // ⭐ 바텀시트가 닫혔다가 다시 열릴 때 저장 상태 초기화
   React.useEffect(() => {
@@ -247,7 +331,39 @@ export default function UserBottomSheet({
     // ⭐ 이미 제출 완료된 경우 저장 방지
     if (hasSubmitted || isReadOnly) {
       console.log('⚠️ [UserBottomSheet] 이미 제출 완료된 콘텐츠입니다. 저장 불가.');
-      Alert.alert('저장 불가', '이미 제출 완료된 콘텐츠는 수정할 수 없습니다.');
+      openModal({
+        width: 344,
+        height: 'auto',
+        closeOnBackdropPress: true,
+        children: (
+          <View style={{ padding: 24, alignItems: 'center' }}>
+            {/* 경고 아이콘 */}
+            <View style={{ marginBottom: 16 }}>
+              <Icon name="error-warning-fill" size={64} color={Colors.red[500]} />
+            </View>
+
+            {/* 타이틀 */}
+            <Text
+              style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
+              저장 불가
+            </Text>
+
+            {/* 설명 */}
+            <Text
+              style={{
+                fontSize: 14,
+                color: Colors.grey[600],
+                marginBottom: 24,
+                textAlign: 'center',
+              }}>
+              이미 제출 완료된 콘텐츠는 수정할 수 없습니다.
+            </Text>
+
+            {/* 확인 버튼 */}
+            <Button label="확인" variant="primary" size="S" fullWidth={true} onPress={closeModal} />
+          </View>
+        ),
+      });
       return;
     }
 
@@ -263,7 +379,50 @@ export default function UserBottomSheet({
     try {
       // ⭐ text_message 필수 검증
       if (!data.textContent || data.textContent.trim().length === 0) {
-        Alert.alert('검증 실패', '텍스트 메시지는 필수입니다.');
+        openModal({
+          width: 344,
+          height: 'auto',
+          closeOnBackdropPress: true,
+          children: (
+            <View style={{ padding: 24, alignItems: 'center' }}>
+              {/* 경고 아이콘 */}
+              <View style={{ marginBottom: 16 }}>
+                <Icon name="error-warning-fill" size={64} color={Colors.red[500]} />
+              </View>
+
+              {/* 타이틀 */}
+              <Text
+                style={{
+                  fontSize: 20,
+                  fontWeight: 'bold',
+                  marginBottom: 8,
+                  textAlign: 'center',
+                }}>
+                검증 실패
+              </Text>
+
+              {/* 설명 */}
+              <Text
+                style={{
+                  fontSize: 14,
+                  color: Colors.grey[600],
+                  marginBottom: 24,
+                  textAlign: 'center',
+                }}>
+                텍스트 메시지는 필수입니다.
+              </Text>
+
+              {/* 확인 버튼 */}
+              <Button
+                label="확인"
+                variant="primary"
+                size="S"
+                fullWidth={true}
+                onPress={closeModal}
+              />
+            </View>
+          ),
+        });
         setIsSaving(false);
         return;
       }
@@ -271,7 +430,50 @@ export default function UserBottomSheet({
       // 제출 전 검증
       const validation = validateContent(data);
       if (!validation.isValid) {
-        Alert.alert('검증 실패', validation.message);
+        openModal({
+          width: 344,
+          height: 'auto',
+          closeOnBackdropPress: true,
+          children: (
+            <View style={{ padding: 24, alignItems: 'center' }}>
+              {/* 경고 아이콘 */}
+              <View style={{ marginBottom: 16 }}>
+                <Icon name="error-warning-fill" size={64} color={Colors.red[500]} />
+              </View>
+
+              {/* 타이틀 */}
+              <Text
+                style={{
+                  fontSize: 20,
+                  fontWeight: 'bold',
+                  marginBottom: 8,
+                  textAlign: 'center',
+                }}>
+                검증 실패
+              </Text>
+
+              {/* 설명 */}
+              <Text
+                style={{
+                  fontSize: 14,
+                  color: Colors.grey[600],
+                  marginBottom: 24,
+                  textAlign: 'center',
+                }}>
+                {validation.message}
+              </Text>
+
+              {/* 확인 버튼 */}
+              <Button
+                label="확인"
+                variant="primary"
+                size="S"
+                fullWidth={true}
+                onPress={closeModal}
+              />
+            </View>
+          ),
+        });
         setIsSaving(false);
         return;
       }
@@ -302,6 +504,8 @@ export default function UserBottomSheet({
       console.log('🎉 [UserBottomSheet] 저장 성공!');
       // ⭐ 저장 성공 시 제출 완료 상태로 설정 (영구적으로 재수정 불가)
       setHasSubmitted(true);
+      // ⭐ 저장 성공 시 다음에 다시 열 때 최신 데이터를 불러올 수 있도록 초기화
+      hasLoadedRef.current = null;
       openModal({
         width: 344,
         height: 'auto',
@@ -401,38 +605,138 @@ export default function UserBottomSheet({
   const handleSave = () => {
     // ⭐ 이미 제출 완료된 경우 또는 읽기 전용 모드인 경우 저장 불가
     if (hasSubmitted || isReadOnly) {
-      Alert.alert('저장 불가', '이미 제출 완료된 콘텐츠는 수정할 수 없습니다.');
+      openModal({
+        width: 344,
+        height: 'auto',
+        closeOnBackdropPress: true,
+        children: (
+          <View style={{ padding: 24, alignItems: 'center' }}>
+            {/* 경고 아이콘 */}
+            <View style={{ marginBottom: 16 }}>
+              <Icon name="error-warning-fill" size={64} color={Colors.red[500]} />
+            </View>
+
+            {/* 타이틀 */}
+            <Text
+              style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
+              저장 불가
+            </Text>
+
+            {/* 설명 */}
+            <Text
+              style={{
+                fontSize: 14,
+                color: Colors.grey[600],
+                marginBottom: 24,
+                textAlign: 'center',
+              }}>
+              이미 제출 완료된 콘텐츠는 수정할 수 없습니다.
+            </Text>
+
+            {/* 확인 버튼 */}
+            <Button label="확인" variant="primary" size="S" fullWidth={true} onPress={closeModal} />
+          </View>
+        ),
+      });
       return;
     }
 
-    // 저장 확인 Alert 표시 (BottomSheet 위에서도 보이도록)
-    Alert.alert(
-      '저장하시겠어요?',
-      '한번 저장한 내용은 수정할 수 없어요',
-      [
-        {
-          text: '취소',
-          style: 'cancel',
-        },
-        {
-          text: '저장하기',
-          style: 'default',
-          onPress: () => {
-            handleFormSubmit();
-          },
-        },
-      ],
-      { cancelable: true }
-    );
+    // 저장 확인 모달 표시
+    openModal({
+      width: 344,
+      height: 'auto',
+      closeOnBackdropPress: true,
+      children: (
+        <View style={{ padding: 24, alignItems: 'center' }}>
+          {/* 아이콘 */}
+          <View style={{ marginBottom: 16 }}>
+            <Icon name="save-line" size={64} color={Colors.blue[500]} />
+          </View>
+
+          {/* 타이틀 */}
+          <Text
+            style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
+            저장하시겠어요?
+          </Text>
+
+          {/* 설명 */}
+          <Text
+            style={{
+              fontSize: 14,
+              color: Colors.grey[600],
+              marginBottom: 24,
+              textAlign: 'center',
+            }}>
+            한번 저장한 내용은 수정할 수 없어요
+          </Text>
+
+          {/* 버튼 */}
+          <DualButton
+            cancelLabel="취소"
+            confirmLabel="저장하기"
+            size="S"
+            cancelVariant="outline"
+            confirmVariant="primary"
+            fullWidth={true}
+            onCancelPress={closeModal}
+            onConfirmPress={() => {
+              closeModal();
+              handleFormSubmit();
+            }}
+          />
+        </View>
+      ),
+    });
   };
 
   // 취소 버튼 핸들러
   const handleCancel = () => {
     if (isDirty) {
-      Alert.alert('작성 취소', '작성 중인 내용이 있습니다. 취소하시겠습니까?', [
-        { text: '계속 작성', style: 'cancel' },
-        { text: '취소', onPress: onClose },
-      ]);
+      openModal({
+        width: 344,
+        height: 'auto',
+        closeOnBackdropPress: true,
+        children: (
+          <View style={{ padding: 24, alignItems: 'center' }}>
+            {/* 아이콘 */}
+            <View style={{ marginBottom: 16 }}>
+              <Icon name="question-line" size={64} color={Colors.blue[500]} />
+            </View>
+
+            {/* 타이틀 */}
+            <Text
+              style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
+              작성 취소
+            </Text>
+
+            {/* 설명 */}
+            <Text
+              style={{
+                fontSize: 14,
+                color: Colors.grey[600],
+                marginBottom: 24,
+                textAlign: 'center',
+              }}>
+              작성 중인 내용이 있습니다. 취소하시겠습니까?
+            </Text>
+
+            {/* 버튼 */}
+            <DualButton
+              cancelLabel="계속 작성"
+              confirmLabel="취소"
+              size="S"
+              cancelVariant="outline"
+              confirmVariant="primary"
+              fullWidth={true}
+              onCancelPress={closeModal}
+              onConfirmPress={() => {
+                closeModal();
+                onClose();
+              }}
+            />
+          </View>
+        ),
+      });
     } else {
       onClose();
     }

--- a/components/timecapsule-create/components/write-bottomsheet/index.tsx
+++ b/components/timecapsule-create/components/write-bottomsheet/index.tsx
@@ -20,7 +20,7 @@ import { Colors } from '@/commons/constants';
 import { AudioAttachment } from '@/components/shared/audio-attachment';
 import React from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { Image, Pressable, Text, TextInput, View } from 'react-native';
+import { Alert, Image, Platform, Pressable, Text, TextInput, View } from 'react-native';
 import Icon from 'react-native-remix-icon';
 import { useMediaPicker, useSubmitContent } from './hooks';
 import { styles } from './styles';
@@ -601,28 +601,63 @@ export default function UserBottomSheet({
   // react-hook-form의 handleSubmit 함수 저장
   const handleFormSubmit = handleSubmit(onFormSubmit);
 
-  // 저장 버튼 핸들러 (확인 모달 먼저 표시)
+  // 저장 버튼 핸들러 (플랫폼별 분기: 웹=Modal, 앱=Alert)
   const handleSave = () => {
+    console.log('🟢 [handleSave] 저장 버튼 클릭됨!');
+    console.log('  - Platform:', Platform.OS);
+
     // ⭐ 이미 제출 완료된 경우 또는 읽기 전용 모드인 경우 저장 불가
     if (hasSubmitted || isReadOnly) {
+      if (Platform.OS === 'web') {
+        openModal({
+          width: 344,
+          height: 'auto',
+          closeOnBackdropPress: true,
+          children: (
+            <View style={{ padding: 24, alignItems: 'center' }}>
+              <View style={{ marginBottom: 16 }}>
+                <Icon name="error-warning-fill" size={64} color={Colors.red[500]} />
+              </View>
+              <Text
+                style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
+                저장 불가
+              </Text>
+              <Text
+                style={{
+                  fontSize: 14,
+                  color: Colors.grey[600],
+                  marginBottom: 24,
+                  textAlign: 'center',
+                }}>
+                이미 제출 완료된 콘텐츠는 수정할 수 없습니다.
+              </Text>
+              <Button label="확인" variant="primary" size="S" fullWidth={true} onPress={closeModal} />
+            </View>
+          ),
+        });
+      } else {
+        Alert.alert('저장 불가', '이미 제출 완료된 콘텐츠는 수정할 수 없습니다.', [
+          { text: '확인', style: 'default' },
+        ]);
+      }
+      return;
+    }
+
+    // ⭐ 플랫폼별 저장 확인 다이얼로그
+    if (Platform.OS === 'web') {
+      // 웹: 커스텀 Modal 사용
       openModal({
         width: 344,
         height: 'auto',
         closeOnBackdropPress: true,
         children: (
           <View style={{ padding: 24, alignItems: 'center' }}>
-            {/* 경고 아이콘 */}
             <View style={{ marginBottom: 16 }}>
-              <Icon name="error-warning-fill" size={64} color={Colors.red[500]} />
+              <Icon name="save-line" size={64} color={Colors.blue[500]} />
             </View>
-
-            {/* 타이틀 */}
-            <Text
-              style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
-              저장 불가
+            <Text style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
+              저장하시겠어요?
             </Text>
-
-            {/* 설명 */}
             <Text
               style={{
                 fontSize: 14,
@@ -630,62 +665,46 @@ export default function UserBottomSheet({
                 marginBottom: 24,
                 textAlign: 'center',
               }}>
-              이미 제출 완료된 콘텐츠는 수정할 수 없습니다.
+              한번 저장한 내용은 수정할 수 없어요
             </Text>
-
-            {/* 확인 버튼 */}
-            <Button label="확인" variant="primary" size="S" fullWidth={true} onPress={closeModal} />
+            <DualButton
+              cancelLabel="취소"
+              confirmLabel="저장하기"
+              size="S"
+              cancelVariant="outline"
+              confirmVariant="primary"
+              fullWidth={true}
+              onCancelPress={closeModal}
+              onConfirmPress={async () => {
+                closeModal();
+                await new Promise((resolve) => setTimeout(resolve, 100));
+                await handleFormSubmit();
+              }}
+            />
           </View>
         ),
       });
-      return;
+    } else {
+      // 앱: React Native Alert 사용
+      Alert.alert(
+        '저장하시겠어요?',
+        '한번 저장한 내용은 수정할 수 없어요',
+        [
+          {
+            text: '취소',
+            style: 'cancel',
+          },
+          {
+            text: '저장하기',
+            style: 'default',
+            onPress: async () => {
+              await handleFormSubmit();
+            },
+          },
+        ],
+        { cancelable: true }
+      );
     }
-
-    // 저장 확인 모달 표시
-    openModal({
-      width: 344,
-      height: 'auto',
-      closeOnBackdropPress: true,
-      children: (
-        <View style={{ padding: 24, alignItems: 'center' }}>
-          {/* 아이콘 */}
-          <View style={{ marginBottom: 16 }}>
-            <Icon name="save-line" size={64} color={Colors.blue[500]} />
-          </View>
-
-          {/* 타이틀 */}
-          <Text style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 8, textAlign: 'center' }}>
-            저장하시겠어요?
-          </Text>
-
-          {/* 설명 */}
-          <Text
-            style={{
-              fontSize: 14,
-              color: Colors.grey[600],
-              marginBottom: 24,
-              textAlign: 'center',
-            }}>
-            한번 저장한 내용은 수정할 수 없어요
-          </Text>
-
-          {/* 버튼 */}
-          <DualButton
-            cancelLabel="취소"
-            confirmLabel="저장하기"
-            size="S"
-            cancelVariant="outline"
-            confirmVariant="primary"
-            fullWidth={true}
-            onCancelPress={closeModal}
-            onConfirmPress={() => {
-              closeModal();
-              handleFormSubmit();
-            }}
-          />
-        </View>
-      ),
-    });
   };
 
   // 취소 버튼 핸들러
@@ -757,8 +776,15 @@ export default function UserBottomSheet({
             cancelVariant="outline"
             confirmVariant="primary"
             confirmDisabled={isSaving || isSubmitting || hasSubmitted} // ⭐ 제출 완료 시에도 비활성화
-            onCancelPress={handleCancel}
-            onConfirmPress={handleSave}
+            onCancelPress={() => {
+              console.log('🔴 [DualButton] 취소 버튼 클릭됨');
+              handleCancel();
+            }}
+            onConfirmPress={() => {
+              console.log('🟢 [DualButton] 저장 버튼 클릭 시도');
+              console.log('  - disabled 상태:', isSaving || isSubmitting || hasSubmitted);
+              handleSave();
+            }}
           />
           <Text style={styles.hintText}>한번 저장한 내용은 수정할 수 없어요</Text>
         </>

--- a/components/timecapsule-create/components/write-bottomsheet/types.ts
+++ b/components/timecapsule-create/components/write-bottomsheet/types.ts
@@ -119,6 +119,8 @@ export interface UserBottomSheetProps {
   onSave?: (content: any) => Promise<void>;
   /** 대기실 설정값 (옵션, 없으면 기본값 사용) */
   roomSettings?: RoomSettingsResponse | null;
+  /** 읽기 전용 모드 (제출 완료된 참여자용) */
+  isReadOnly?: boolean;
 }
 
 /**

--- a/components/toss-payments/api/payment.ts
+++ b/components/toss-payments/api/payment.ts
@@ -313,12 +313,30 @@ export const getMyPayments = async ({
   status = 'ALL',
 }: GetMyPaymentsParams = {}): Promise<PaymentListResponse> => {
   try {
+    console.log('🌐 [getMyPayments] API 호출 시작');
+    console.log('  - Endpoint:', `/${API_ENDPOINTS.PAYMENT.TOSS_MY_PAYMENTS}`);
+    console.log('  - Method: GET');
+    console.log('  - Params:', { page, limit, status });
+    console.log('  - Base URL:', apiClient.defaults.baseURL || '설정되지 않음');
+
     const response = await apiClient.get<PaymentListResponse>(
       `/${API_ENDPOINTS.PAYMENT.TOSS_MY_PAYMENTS}`,
       {
         params: { page, limit, status },
       },
     );
+
+    console.log('✅ [getMyPayments] API 호출 성공');
+    console.log('  - Status:', response.status);
+    console.log('  - Response Data (상세):', JSON.stringify(response.data, null, 2));
+    console.log('  - 요약:', {
+      paymentsCount: response.data.payments?.length || 0,
+      total: response.data.total,
+      page: response.data.page,
+      limit: response.data.limit,
+    });
+    console.log('  - Payments 배열:', response.data.payments);
+
     return response.data;
   } catch (error: any) {
     const statusCode = error.response?.status || 0;

--- a/components/toss-payments/components/payment-history/index.tsx
+++ b/components/toss-payments/components/payment-history/index.tsx
@@ -56,13 +56,39 @@ export const PaymentHistory: React.FC = () => {
   const [isDetailVisible, setIsDetailVisible] = useState(false);
 
   // API 호출
-  const { data } = useMyPayments({
+  const { data, isLoading, error } = useMyPayments({
     page: 1,
     limit: 100, // 일단 많은 양을 가져옴 (추후 무한스크롤 추가 가능)
     status: 'ALL',
   });
 
   const allPayments = data?.payments || [];
+
+  // 디버깅: API 응답 확인
+  React.useEffect(() => {
+    if (data) {
+      console.log('📊 [PaymentHistory] API 응답 데이터 (상세):', JSON.stringify(data, null, 2));
+      console.log('📊 [PaymentHistory] 요약:', {
+        paymentsCount: data.payments?.length || 0,
+        total: data.total,
+        page: data.page,
+        limit: data.limit,
+      });
+      console.log('📊 [PaymentHistory] Payments 배열:', data.payments);
+
+      // 데이터 불일치 체크
+      if (data.total && data.total !== (data.payments?.length || 0)) {
+        console.warn('⚠️ [PaymentHistory] 데이터 불일치 감지!', {
+          total: data.total,
+          actualCount: data.payments?.length || 0,
+          difference: data.total - (data.payments?.length || 0),
+        });
+      }
+    }
+    if (error) {
+      console.error('❌ [PaymentHistory] API 에러:', JSON.stringify(error, null, 2));
+    }
+  }, [data, error]);
 
   // 헤더 닫기 핸들러
   const handleClose = () => {
@@ -232,7 +258,10 @@ export const PaymentHistory: React.FC = () => {
       <View style={styles.header}>
         <View style={styles.headerLeft}>
           <Text style={styles.headerTitle}>결제 내역</Text>
-          <Text style={styles.headerSubtitle}>총 {allPayments.length}건의 결제</Text>
+          <Text style={styles.headerSubtitle}>
+            총 {data?.total ?? allPayments.length}건의 결제
+            {data && data.total !== allPayments.length && ` (표시: ${allPayments.length}건)`}
+          </Text>
         </View>
         <Pressable style={styles.headerCloseButton} onPress={handleClose}>
           <Icon name="close-line" size={24} color={Colors.black[500]} />


### PR DESCRIPTION
## 📌 관련 이슈 (Task ID)

- ID: CAP-05

## 📝 작업 내용 (Details)

### 1. 타임캡슐 콘텐츠 작성 기능 개선 및 참가자 관리 로직 최적화

- [x] 바텀시트에 오디오 첨부 기능 및 읽기 전용 모드 추가
- [x] 콘텐츠 제출 상태 관리 로직 개선 (서버 status 기반 제출 완료 판단)
- [x] 참가자 목록 새로고침 기능 추가 및 데이터 페칭 로직 최적화
- [x] 콘텐츠 불러오기 시 participant.content 폴백 제거 (서버가 소스 오브 트루스)
- [x] 내 캡슐 상세 페이지 UI 및 API 로직 개선
- [x] 미디어 타입 상수 정의 개선

### 2. 바텀시트 UI 개선 및 콘텐츠 로딩 최적화

- [x] Alert.alert를 커스텀 모달 컴포넌트로 교체하여 일관된 UI 제공
- [x] 콘텐츠 불러오기 로직 최적화 (hasLoadedRef로 중복 API 호출 방지)
- [x] 텍스트 메시지 필수 검증 추가 및 에러 모달 구현
- [x] 음악 교체 확인 모달을 커스텀 모달로 변경
- [x] step-room 스타일 및 참가자 관리 로직 개선
- [x] useMediaPicker, useSubmitContent 훅 로직 개선

### 3. 타임캡슐 및 결제 기능 디버깅 로그 추가 및 UI 개선

- [x] step-room 관련 훅에 디버깅 로그 추가
- [x] 결제 내역 페이지 UI 개선 및 API 연동
- [x] 디버깅 로그 추가로 개발 중 문제 추적 용이성 향상

### 4. BottomSheet footer 버튼 클릭 오류 수정 및 플랫폼별 저장 확인 다이얼로그 구현

- [x] BottomSheet PanResponder 설정 수정: footer 영역 버튼 클릭 가능하도록 개선
  - onStartShouldSetPanResponder 기본값을 false로 변경하여 버튼 클릭 우선 처리
  - 최소 5px 이상 이동해야 드래그로 인식하도록 임계값 추가
  - footer 영역에 pointerEvents='auto' 설정하여 PanResponder 영향 제거
- [x] 플랫폼별 저장 확인 다이얼로그 구현
  - 웹: 커스텀 Modal 컴포넌트 사용 (DualButton 적용)
  - 앱: React Native Alert API 사용
  - 저장 불가 상황(이미 제출 완료) 알림도 플랫폼별로 분기 처리
- [x] Modal z-index 및 elevation 추가: 다른 Modal 위에 정상 표시되도록 수정
- [x] 디버깅 로그 추가: Button, ModalProvider, BottomSheet PanResponder 동작 추적용

## 📸 스크린샷 (Screenshots)

(추가 필요)

## 🧐 리뷰 포인트 (Review Point)

- **BottomSheet PanResponder 로직**: footer 버튼 클릭이 정상 작동하는지, 드래그 제스처와 충돌하지 않는지 확인 필요
- **플랫폼별 분기 처리**: 웹/앱 환경에서 저장 확인 다이얼로그가 정상 작동하는지 확인 필요
- **서버 상태 기반 제출 완료 판단**: participant.content 폴백 제거로 인한 영향 검토 필요
- **콘텐츠 로딩 최적화**: hasLoadedRef를 통한 중복 API 호출 방지 로직 검토
- **디버깅 로그**: 프로덕션 환경에서 제거 또는 개발 환경에서만 동작하도록 수정 필요
- **Modal z-index**: 9999, 10000 값이 적절한지, 다른 모달과 충돌하지 않는지 확인 필요

## ✅ 체크리스트 (Checklist)

- [x] 컨벤션(커밋, 브랜치 네이밍)을 준수했나요?
- [ ] 불필요한 콘솔 로그(console.log)나 주석을 제거했나요?
  - ⚠️ 디버깅용 console.log 다수 포함 (개발 환경에서만 동작하도록 수정 또는 제거 필요)
- [ ] 실행 시 에러가 발생하지 않나요?
 