### PR TITLE
[Refactor/form] 플랫폼별 오디오 녹음 및 재생 호환성 개선

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -101,6 +101,12 @@ module.exports = {
             '$(PRODUCT_NAME)이(가) 위치 정보를 사용하여 주변 타임캡슐을 찾습니다.',
         },
       ],
+      [
+        'expo-audio',
+        {
+          microphonePermission: 'Allow $(PRODUCT_NAME) to access your microphone.',
+        },
+      ],
     ],
     experiments: {
       typedRoutes: true,

--- a/commons/constants/media.ts
+++ b/commons/constants/media.ts
@@ -6,11 +6,15 @@
 // 미디어 타입 정의
 export type MediaType = 'IMAGE' | 'VIDEO' | 'AUDIO';
 
-// 화이트리스트 정의
+// 화이트리스트 정의 (백엔드 허용 형식에 맞춤)
+// 백엔드 허용 MIME 타입:
+// - IMAGE: image/jpeg, image/jpg, image/png, image/webp (최대 5MB)
+// - VIDEO: video/mp4, video/webm (최대 200MB)
+// - AUDIO: audio/mpeg, audio/mp3, audio/mp4, audio/x-m4a, audio/aac, audio/m4a, audio/x-aac (최대 20MB)
 export const ALLOWED_EXTENSIONS = {
   IMAGE: ['jpeg', 'jpg', 'png', 'webp'],
-  VIDEO: ['mp4'],
-  AUDIO: ['mpeg', 'aac', 'm4a'],
+  VIDEO: ['mp4', 'webm'],
+  AUDIO: ['mpeg', 'mp3', 'mp4', 'm4a', 'aac'], // webm, ogg, wav 제거 (백엔드 미지원)
 } as const;
 
 // 용량 제한 (바이트 단위)
@@ -20,7 +24,7 @@ export const SIZE_LIMITS = {
   AUDIO: 20 * 1024 * 1024, // 20MB
 } as const;
 
-// MIME Type 매핑
+// MIME Type 매핑 (백엔드 허용 형식에 맞춤)
 export const MIME_TYPE_MAP: Record<string, string> = {
   // IMAGE
   jpeg: 'image/jpeg',
@@ -29,8 +33,10 @@ export const MIME_TYPE_MAP: Record<string, string> = {
   webp: 'image/webp',
   // VIDEO
   mp4: 'video/mp4',
-  // AUDIO
+  webm: 'video/webm',
+  // AUDIO (백엔드 허용 MIME 타입만 포함)
   mpeg: 'audio/mpeg',
-  aac: 'audio/aac',
+  mp3: 'audio/mp3',
   m4a: 'audio/m4a',
+  aac: 'audio/aac',
 };

--- a/commons/layout/Tabs/TabLayout/styles.ts
+++ b/commons/layout/Tabs/TabLayout/styles.ts
@@ -17,7 +17,7 @@ export const TABS_SETTINGS = {
     backgroundColor: Colors.white[50],
     borderTopWidth: 1,
     borderTopColor: Colors.grey[200],
-    height: 68,
+    height: 84,
     paddingBottom: 12,
     paddingTop: 12,
   },

--- a/components/map/components/egg-form/hooks/useEggForm.ts
+++ b/components/map/components/egg-form/hooks/useEggForm.ts
@@ -11,7 +11,7 @@
  */
 
 import { API_ENDPOINTS, queryKeys } from '@/commons/constants';
-import { MediaType } from '@/commons/constants/media';
+import { MediaType, MIME_TYPE_MAP } from '@/commons/constants/media';
 import { useAuth } from '@/commons/layout/provider/auth/auth.provider';
 import { useMapLocation } from '@/components/map/components/map-view/hooks/useMapLocation';
 import { buildApiUrl, getMimeTypes, normalizeApiBaseUrl } from '@/utils';
@@ -303,30 +303,20 @@ export function useEggForm({ onClose }: UseEggFormProps) {
     return fileName;
   };
 
-  // URI에서 파일 확장자를 추출하여 MIME 타입 반환 (타임캡슐 제출 로직과 동일)
+  // URI에서 파일 확장자를 추출하여 MIME 타입 반환
+  // MIME_TYPE_MAP을 사용하되, 매핑이 없으면 기본값 반환
   const getMimeType = (uri: string, mediaType: MediaType): string => {
     const extension = uri.split('.').pop()?.toLowerCase() || '';
+    const mimeType = MIME_TYPE_MAP[extension];
 
-    if (mediaType === 'IMAGE') {
-      if (extension === 'jpg' || extension === 'jpeg') return 'image/jpeg';
-      if (extension === 'png') return 'image/png';
-      if (extension === 'gif') return 'image/gif';
-      return 'image/jpeg'; // 기본값
+    if (mimeType) {
+      return mimeType;
     }
 
-    if (mediaType === 'AUDIO') {
-      if (extension === 'mp3') return 'audio/mpeg';
-      if (extension === 'm4a') return 'audio/mp4';
-      if (extension === 'wav') return 'audio/wav';
-      return 'audio/mpeg'; // 기본값
-    }
-
-    if (mediaType === 'VIDEO') {
-      if (extension === 'mp4') return 'video/mp4';
-      if (extension === 'mov') return 'video/quicktime';
-      if (extension === 'avi') return 'video/x-msvideo';
-      return 'video/mp4'; // 기본값
-    }
+    // 매핑이 없는 경우 기본값 반환
+    if (mediaType === 'IMAGE') return 'image/jpeg';
+    if (mediaType === 'AUDIO') return 'audio/mpeg';
+    if (mediaType === 'VIDEO') return 'video/mp4';
 
     return 'application/octet-stream';
   };

--- a/components/my-egg-list/components/item/index.tsx
+++ b/components/my-egg-list/components/item/index.tsx
@@ -106,12 +106,16 @@ export function Item({
                       color={Colors.darkGrey[600]}
                     />
                   </View>
-                  <Text style={styles.metaText}>{location}</Text>
+                  <Text style={styles.metaText} numberOfLines={1} ellipsizeMode="tail">
+                    {location}
+                  </Text>
                 </View>
                 <View style={styles.divider} />
               </>
             )}
-            <Text style={styles.metaText}>{date}</Text>
+            <Text style={styles.metaText} numberOfLines={1} ellipsizeMode="tail">
+              {date}
+            </Text>
           </View>
           <View style={styles.actionContainer}>
             {hasImage && (

--- a/components/my-egg-list/components/item/styles.ts
+++ b/components/my-egg-list/components/item/styles.ts
@@ -135,14 +135,19 @@ export const styles = StyleSheet.create({
     borderTopColor: Colors.border.lighter, // rgba(10,10,10,0.06)
   },
   metaContainer: {
+    flex: 1,
+    flexShrink: 1,
     flexDirection: 'row',
     alignItems: 'center',
     gap: 10, // 8px → 10px
+    minWidth: 0, // flex shrink를 위한 필수 속성
   },
   locationContainer: {
+    flexShrink: 1,
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4, // 2px → 4px (아이콘과 텍스트 간격)
+    minWidth: 0, // flex shrink를 위한 필수 속성
   },
   locationIconContainer: {
     width: 14, // 12px → 14px (약간 더 큰 아이콘)
@@ -151,6 +156,7 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
   },
   metaText: {
+    flexShrink: 1,
     fontFamily: Typography.body.body8.fontFamily,
     fontSize: 12,
     lineHeight: 16,

--- a/components/my-egg-list/components/modal/index.tsx
+++ b/components/my-egg-list/components/modal/index.tsx
@@ -17,8 +17,8 @@
  */
 
 import { Image } from 'expo-image';
-import React from 'react';
-import { Pressable, ScrollView, Text, View } from 'react-native';
+import React, { useMemo } from 'react';
+import { Dimensions, Pressable, ScrollView, Text, View } from 'react-native';
 import Icon from 'react-native-remix-icon';
 
 import { Modal } from '@/commons/components/modal';
@@ -58,6 +58,12 @@ export const EasterEggModal: React.FC<EasterEggModalProps> = ({ visible, onClose
     getCurrentUserViewedAt,
   } = useEasterEggModal({ data });
 
+  // 화면 높이의 90%를 계산하여 최대 높이 제한
+  const maxHeight = useMemo(() => {
+    const screenHeight = Dimensions.get('window').height;
+    return screenHeight * 0.8;
+  }, []);
+
   // 데이터가 없으면 빈 모달 반환 (항상 같은 구조 유지)
   if (!data) {
     return (
@@ -68,7 +74,7 @@ export const EasterEggModal: React.FC<EasterEggModalProps> = ({ visible, onClose
         height="100%"
         padding={0}
         closeOnBackdropPress>
-        <View style={styles.scrollViewWrapper}>
+        <View style={[styles.scrollViewWrapper, { maxHeight }]}>
           <Pressable style={styles.closeButton} onPress={onClose}>
             <Icon name="close-line" size={20} color={Colors.black[500]} />
           </Pressable>
@@ -119,11 +125,11 @@ export const EasterEggModal: React.FC<EasterEggModalProps> = ({ visible, onClose
       visible={visible}
       onClose={onClose}
       width={340}
-      height="80%"
+      height="auto"
       padding={0}
       closeOnBackdropPress
       disableAnimation={false}>
-      <View style={styles.scrollViewWrapper}>
+      <View style={[styles.scrollViewWrapper, { maxHeight }]}>
         {/* 닫기 버튼 (우측 상단) */}
         <Pressable style={styles.closeButton} onPress={onClose}>
           <Icon name="close-line" size={20} color={Colors.black[500]} />

--- a/components/my-egg-list/components/modal/index.tsx
+++ b/components/my-egg-list/components/modal/index.tsx
@@ -65,7 +65,7 @@ export const EasterEggModal: React.FC<EasterEggModalProps> = ({ visible, onClose
         visible={visible}
         onClose={onClose}
         width={340}
-        height="auto"
+        height="100%"
         padding={0}
         closeOnBackdropPress>
         <View style={styles.scrollViewWrapper}>
@@ -109,9 +109,7 @@ export const EasterEggModal: React.FC<EasterEggModalProps> = ({ visible, onClose
         )}
 
         {/* 비디오 플레이어 렌더링 */}
-        {hasVideo && data.videoMediaId && (
-          <VideoPlayer mediaId={data.videoMediaId} />
-        )}
+        {hasVideo && data.videoMediaId && <VideoPlayer mediaId={data.videoMediaId} />}
       </View>
     );
   };
@@ -209,17 +207,6 @@ export const EasterEggModal: React.FC<EasterEggModalProps> = ({ visible, onClose
             {/* 미디어 렌더링 */}
             {renderMedia()}
 
-            {/* TODO: 테스트용 - 확인 후 삭제 */}
-            <View style={{ marginTop: 20, marginBottom: 20 }}>
-              <Text style={{ marginBottom: 10, fontSize: 14, fontWeight: 'bold', color: Colors.black[500] }}>
-                [테스트] 비디오 플레이어 예시
-              </Text>
-              <VideoPlayer
-                mediaId="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
-                thumbnailUrl={undefined}
-              />
-            </View>
-
             {/* 발견한 사람들 목록 (PLANTED 타입일 때만, 0명일 때도 공간 유지) */}
             {data.type === 'PLANTED' && (
               <View style={styles.viewersSection}>
@@ -237,12 +224,12 @@ export const EasterEggModal: React.FC<EasterEggModalProps> = ({ visible, onClose
 
                       return (
                         <View key={viewer.id} style={styles.viewerItem}>
-                          <View style={styles.viewerInfo}>
-                            <View style={styles.viewerAvatar}>
+                          <View style={styles.discovererViewerInfo}>
+                            <View style={styles.discovererViewerAvatar}>
                               {viewerProfileImg ? (
                                 <Image
                                   source={{ uri: viewerProfileImg }}
-                                  style={styles.viewerAvatarImage}
+                                  style={styles.discovererViewerAvatarImage}
                                   contentFit="cover"
                                   accessibilityLabel={`${viewer.nickname} 프로필 이미지`}
                                 />

--- a/components/my-egg-list/components/modal/styles.ts
+++ b/components/my-egg-list/components/modal/styles.ts
@@ -18,7 +18,6 @@ export const styles = StyleSheet.create({
   // ScrollView를 감싸는 래퍼 (Modal 내부 높이 확보용)
   scrollViewWrapper: {
     width: '100%',
-    height: '100%', // Modal의 높이를 모두 사용
     maxWidth: '100%', // iOS에서 너비 제한
     position: 'relative',
     overflow: 'hidden', // 콘텐츠가 밖으로 나가지 않도록
@@ -28,7 +27,6 @@ export const styles = StyleSheet.create({
   // ScrollView 컨테이너
   scrollView: {
     width: '100%',
-    height: '100%', // 부모 높이를 모두 사용
     maxWidth: '100%', // iOS에서 너비 제한
     alignSelf: 'stretch', // iOS에서 부모 너비에 맞춤
   },
@@ -40,7 +38,6 @@ export const styles = StyleSheet.create({
     paddingBottom: Spacing.xl * 1.5, // 하단 패딩 제거 (하얀 부분 제거)
     width: '100%',
     maxWidth: '100%', // iOS에서 너비 제한
-    flexGrow: 1, // 스크롤을 위해 flexGrow 활성화
     alignItems: 'center',
     gap: Spacing.lg, // 24px - 일관된 간격
     alignSelf: 'stretch', // iOS에서 부모 너비에 맞춤

--- a/components/my-egg-list/components/modal/styles.ts
+++ b/components/my-egg-list/components/modal/styles.ts
@@ -18,8 +18,8 @@ export const styles = StyleSheet.create({
   // ScrollView를 감싸는 래퍼 (Modal 내부 높이 확보용)
   scrollViewWrapper: {
     width: '100%',
+    height: '100%', // Modal의 높이를 모두 사용
     maxWidth: '100%', // iOS에서 너비 제한
-    maxHeight: '80%', // 모달 최대 높이 제한
     position: 'relative',
     overflow: 'hidden', // 콘텐츠가 밖으로 나가지 않도록
     alignSelf: 'stretch', // iOS에서 부모 너비에 맞춤
@@ -28,6 +28,7 @@ export const styles = StyleSheet.create({
   // ScrollView 컨테이너
   scrollView: {
     width: '100%',
+    height: '100%', // 부모 높이를 모두 사용
     maxWidth: '100%', // iOS에서 너비 제한
     alignSelf: 'stretch', // iOS에서 부모 너비에 맞춤
   },
@@ -36,7 +37,7 @@ export const styles = StyleSheet.create({
   modalContent: {
     paddingHorizontal: Spacing.xl, // 32px
     paddingTop: Spacing.xl * 1.5, // 48px (상단 패딩 더 추가)
-    paddingBottom: 0, // 하단 패딩 제거 (하얀 부분 제거)
+    paddingBottom: Spacing.xl * 1.5, // 하단 패딩 제거 (하얀 부분 제거)
     width: '100%',
     maxWidth: '100%', // iOS에서 너비 제한
     flexGrow: 1, // 스크롤을 위해 flexGrow 활성화
@@ -290,7 +291,6 @@ export const styles = StyleSheet.create({
     lineHeight: 22, // 가독성 향상
   },
 
-
   // 방문자 정보 컨테이너
   viewerInfo: {
     flexDirection: 'row',
@@ -368,14 +368,14 @@ export const styles = StyleSheet.create({
   },
 
   // 발견한 사람 정보 (아바타 + 이름)
-  viewerInfo: {
+  discovererViewerInfo: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: Spacing.sm, // 8px
   },
 
   // 발견한 사람 아바타
-  viewerAvatar: {
+  discovererViewerAvatar: {
     width: 28,
     height: 28,
     borderRadius: BorderRadius.full,
@@ -388,7 +388,7 @@ export const styles = StyleSheet.create({
   },
 
   // 발견한 사람 아바타 이미지
-  viewerAvatarImage: {
+  discovererViewerAvatarImage: {
     width: 28,
     height: 28,
     borderRadius: BorderRadius.full,

--- a/components/my-egg-list/hooks/useMyEggs.ts
+++ b/components/my-egg-list/hooks/useMyEggs.ts
@@ -183,9 +183,8 @@ const transformFoundEggItem = (
   item: FoundEggItem,
   addressMap: Map<string, string>,
 ): EasterEggItem => {
-  // foundDate를 포맷팅하여 "발견한 날: YYYY-MM-DD" 형식으로 변환
+  // foundDate를 포맷팅하여 YYYY-MM-DD 형식으로 변환
   const formattedDate = formatDate(item.foundDate);
-  const dateWithLabel = `발견한 날: ${formattedDate}`;
 
   const itemKey = `${item.eggId}-location`;
   // addressMap에 변환된 주소가 있으면 사용
@@ -206,7 +205,7 @@ const transformFoundEggItem = (
     title: item.title,
     description: item.content || '',
     location,
-    date: dateWithLabel,
+    date: formattedDate,
     eggIcon: require('@/assets/images/filled_egg.svg'),
     hasImage: item.hasImage,
     hasAudio: item.hasAudio,

--- a/components/shared/audio-attachment/hooks/useAudioPreview.ts
+++ b/components/shared/audio-attachment/hooks/useAudioPreview.ts
@@ -4,12 +4,12 @@
  *
  * 생성 시각: 2025-01-XX
  * 규칙 준수 체크리스트:
- * - [x] expo-av Audio.Sound 사용
+ * - [x] expo-audio 사용 (expo-av에서 마이그레이션)
  * - [x] 재생 상태 관리
  */
 
-import { Audio } from 'expo-av';
-import { useEffect, useRef, useState } from 'react';
+import { useAudioPlayer, useAudioPlayerStatus } from 'expo-audio';
+import { useEffect, useMemo } from 'react';
 
 interface UseAudioPreviewReturn {
   /** 재생 중 여부 */
@@ -31,84 +31,30 @@ interface UseAudioPreviewReturn {
  * 로컬 URI의 오디오 파일을 재생하는 기능 제공
  */
 export const useAudioPreview = (uri: string | null): UseAudioPreviewReturn => {
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [positionMillis, setPositionMillis] = useState(0);
-  const [durationMillis, setDurationMillis] = useState(0);
-  const soundRef = useRef<Audio.Sound | null>(null);
+  // expo-audio의 useAudioPlayer hook 사용
+  const player = useAudioPlayer(uri);
+  const status = useAudioPlayerStatus(player);
 
-  // URI 변경 시 Sound 객체 생성
+  // 재생 완료 시 자동 리셋
   useEffect(() => {
-    if (!uri) {
-      return;
+    if (status.isLoaded && status.didJustFinish) {
+      player.seekTo(0);
     }
-
-    const loadSound = async () => {
-      try {
-        // 기존 Sound 객체가 있으면 정리
-        if (soundRef.current) {
-          await soundRef.current.unloadAsync();
-        }
-
-        // 새로운 Sound 객체 생성
-        const { sound } = await Audio.Sound.createAsync(
-          { uri },
-          { shouldPlay: false },
-          (status) => {
-            if (status.isLoaded) {
-              setPositionMillis(status.positionMillis || 0);
-              setDurationMillis(status.durationMillis || 0);
-
-              // 재생 완료 시
-              if (status.didJustFinish) {
-                setIsPlaying(false);
-                setPositionMillis(0);
-              }
-            }
-          },
-        );
-
-        soundRef.current = sound;
-
-        // 초기 duration 가져오기
-        const status = await sound.getStatusAsync();
-        if (status.isLoaded) {
-          setDurationMillis(status.durationMillis || 0);
-        }
-      } catch (error) {
-        console.error('오디오 로드 오류:', error);
-      }
-    };
-
-    loadSound();
-
-    // 정리 함수
-    return () => {
-      if (soundRef.current) {
-        soundRef.current.unloadAsync().catch(console.error);
-      }
-    };
-  }, [uri]);
+  }, [status.didJustFinish, status.isLoaded, player]);
 
   /**
    * 재생 시작/일시정지 토글
    */
   const togglePlay = async (): Promise<void> => {
-    if (!soundRef.current) {
+    if (!status.isLoaded) {
       return;
     }
 
     try {
-      const status = await soundRef.current.getStatusAsync();
-      if (!status.isLoaded) {
-        return;
-      }
-
-      if (status.isPlaying) {
-        await soundRef.current.pauseAsync();
-        setIsPlaying(false);
+      if (status.playing) {
+        player.pause();
       } else {
-        await soundRef.current.playAsync();
-        setIsPlaying(true);
+        player.play();
       }
     } catch (error) {
       console.error('재생 토글 오류:', error);
@@ -119,15 +65,13 @@ export const useAudioPreview = (uri: string | null): UseAudioPreviewReturn => {
    * 재생 중지 및 리셋
    */
   const stop = async (): Promise<void> => {
-    if (!soundRef.current) {
+    if (!status.isLoaded) {
       return;
     }
 
     try {
-      await soundRef.current.stopAsync();
-      await soundRef.current.setPositionAsync(0);
-      setIsPlaying(false);
-      setPositionMillis(0);
+      player.pause();
+      player.seekTo(0);
     } catch (error) {
       console.error('재생 중지 오류:', error);
     }
@@ -135,23 +79,32 @@ export const useAudioPreview = (uri: string | null): UseAudioPreviewReturn => {
 
   /**
    * 리소스 정리
+   * expo-audio는 자동으로 정리되므로 별도 작업 불필요
    */
   const unload = async (): Promise<void> => {
-    if (soundRef.current) {
-      try {
-        await soundRef.current.unloadAsync();
-        soundRef.current = null;
-      } catch (error) {
-        console.error('리소스 정리 오류:', error);
+    // expo-audio는 컴포넌트 언마운트 시 자동으로 정리됨
+    try {
+      if (status.isLoaded) {
+        player.pause();
+        player.seekTo(0);
       }
+    } catch (error) {
+      console.error('리소스 정리 오류:', error);
     }
-    setIsPlaying(false);
-    setPositionMillis(0);
-    setDurationMillis(0);
   };
 
+  // 밀리초 단위로 변환
+  const positionMillis = useMemo(
+    () => Math.floor((status.currentTime || 0) * 1000),
+    [status.currentTime],
+  );
+  const durationMillis = useMemo(
+    () => Math.floor((status.duration || 0) * 1000),
+    [status.duration],
+  );
+
   return {
-    isPlaying,
+    isPlaying: status.playing || false,
     positionMillis,
     durationMillis,
     togglePlay,

--- a/components/shared/audio-attachment/hooks/useAudioRecorder.ts
+++ b/components/shared/audio-attachment/hooks/useAudioRecorder.ts
@@ -4,14 +4,21 @@
  *
  * 생성 시각: 2025-01-XX
  * 규칙 준수 체크리스트:
- * - [x] expo-av 사용
+ * - [x] expo-audio 사용 (expo-av에서 마이그레이션)
  * - [x] API 호출 제외 (로컬 URI만 반환)
  * - [x] 녹음 시간 타이머 구현
  */
 
-import { Audio } from 'expo-av';
+import {
+  RecordingPresets,
+  requestRecordingPermissionsAsync,
+  setAudioModeAsync,
+  useAudioRecorderState,
+  useAudioRecorder as useExpoAudioRecorder,
+  type RecordingOptions,
+} from 'expo-audio';
 import { useEffect, useRef, useState } from 'react';
-import { Alert } from 'react-native';
+import { Alert, Platform } from 'react-native';
 
 interface UseAudioRecorderReturn {
   /** 녹음 중 여부 */
@@ -27,18 +34,49 @@ interface UseAudioRecorderReturn {
 }
 
 /**
+ * 플랫폼별 녹음 설정
+ *
+ * 문제: 백엔드가 audio/webm을 지원하지 않음
+ * 해결:
+ * - iOS/Android: m4a로 녹음 (네이티브 지원)
+ * - 웹: 브라우저가 지원하는 형식으로 녹음 후 서버에서 변환 필요
+ *      또는 mp3로 녹음 시도 (일부 브라우저 지원)
+ */
+const getRecordingOptions = (): RecordingOptions => {
+  if (Platform.OS === 'web') {
+    // 웹에서는 브라우저가 지원하는 형식 사용
+    // 대부분의 브라우저는 webm을 지원하지만, 백엔드가 받지 않음
+    // 일단 HIGH_QUALITY 프리셋 사용 (브라우저가 알아서 선택)
+    if (__DEV__) {
+      console.log('[AudioRecorder] 웹 환경: 브라우저 기본 녹음 형식 사용');
+    }
+    return RecordingPresets.HIGH_QUALITY;
+  }
+
+  // iOS/Android: m4a로 녹음
+  return {
+    ...RecordingPresets.HIGH_QUALITY,
+    extension: '.m4a',
+  };
+};
+
+/**
  * 오디오 녹음 Hook
  * 녹음과 로컬 URI 생성만 담당하고, API 호출은 제외
  */
 export const useAudioRecorder = (): UseAudioRecorderReturn => {
-  const [isRecording, setIsRecording] = useState(false);
   const [recordingDuration, setRecordingDuration] = useState(0);
-  const [recording, setRecording] = useState<Audio.Recording | null>(null);
+  const isPreparing = useRef(false);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // expo-audio의 useAudioRecorder hook 사용 (플랫폼별 설정 적용)
+  const recordingOptions = getRecordingOptions();
+  const recorder = useExpoAudioRecorder(recordingOptions);
+  const recorderState = useAudioRecorderState(recorder);
 
   // 녹음 시간 업데이트
   useEffect(() => {
-    if (isRecording) {
+    if (recorderState.isRecording) {
       intervalRef.current = setInterval(() => {
         setRecordingDuration((prev) => prev + 1);
       }, 1000);
@@ -47,6 +85,10 @@ export const useAudioRecorder = (): UseAudioRecorderReturn => {
         clearInterval(intervalRef.current);
         intervalRef.current = null;
       }
+      // 녹음이 중지되면 시간 리셋
+      if (!recorderState.isRecording) {
+        setRecordingDuration(0);
+      }
     }
 
     return () => {
@@ -54,57 +96,43 @@ export const useAudioRecorder = (): UseAudioRecorderReturn => {
         clearInterval(intervalRef.current);
       }
     };
-  }, [isRecording]);
+  }, [recorderState.isRecording]);
 
   /**
    * 녹음 시작
    */
   const startRecording = async (): Promise<void> => {
-    try {
-      // 이미 녹음 중이면 무시
-      if (isRecording) {
-        console.warn('녹음이 이미 진행 중입니다.');
-        return;
-      }
+    // 중복 호출 방지
+    if (isPreparing.current || recorderState.isRecording) {
+      console.warn('녹음이 이미 진행 중이거나 준비 중입니다.');
+      return;
+    }
+    isPreparing.current = true;
 
-      // 권한 요청
-      const { status } = await Audio.requestPermissionsAsync();
-      if (status !== 'granted') {
+    try {
+      // 권한 확인
+      const { granted } = await requestRecordingPermissionsAsync();
+      if (!granted) {
         Alert.alert('권한 필요', '마이크 접근 권한이 필요합니다.');
         return;
       }
 
-      // 기존 녹음기가 남아있으면 정리 (상태 동기화 문제 방지)
-      if (recording) {
-        try {
-          await recording.stopAndUnloadAsync();
-        } catch (cleanupError) {
-          // 정리 오류는 무시 (이미 정리된 상태일 수 있음)
-          console.warn('기존 녹음기 정리 중 오류 (무시됨):', cleanupError);
-        }
-        setRecording(null);
-      }
-
       // 오디오 모드 설정
-      await Audio.setAudioModeAsync({
-        allowsRecordingIOS: true,
-        playsInSilentModeIOS: true,
+      await setAudioModeAsync({
+        allowsRecording: true,
+        playsInSilentMode: true,
+        shouldPlayInBackground: false,
+        interruptionMode: 'doNotMix',
       });
 
-      // 녹음 시작
-      const { recording: newRecording } = await Audio.Recording.createAsync(
-        Audio.RecordingOptionsPresets.HIGH_QUALITY,
-      );
-
-      setRecording(newRecording);
-      setIsRecording(true);
-      setRecordingDuration(0);
+      // 녹음 준비 및 시작
+      await recorder.prepareToRecordAsync();
+      recorder.record();
     } catch (error) {
       console.error('녹음 시작 오류:', error);
-      Alert.alert('오류', '녹음을 시작할 수 없습니다.');
-      // 오류 발생 시 상태 리셋
-      setRecording(null);
-      setIsRecording(false);
+      Alert.alert('오류', '녹음을 시작할 수 없습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      isPreparing.current = false;
     }
   };
 
@@ -113,21 +141,26 @@ export const useAudioRecorder = (): UseAudioRecorderReturn => {
    * S3 업로드는 하지 않고 로컬 URI만 반환
    */
   const stopRecording = async (): Promise<string | null> => {
-    if (!recording) {
-      return null;
-    }
-
     try {
-      await recording.stopAndUnloadAsync();
-      const uri = recording.getURI();
+      await recorder.stop();
+      const uri = recorder.uri;
 
-      setRecording(null);
-      setIsRecording(false);
+      if (__DEV__ && uri) {
+        console.log('[AudioRecorder] 녹음 완료');
+        console.log('  - URI:', uri);
+        console.log('  - Platform:', Platform.OS);
+
+        // URI에서 확장자 추출
+        const extension = uri.split('.').pop()?.split('?')[0].toLowerCase();
+        console.log('  - 실제 녹음 형식:', extension);
+      }
+
+      // 녹음 종료 후 오디오 모드 복구 (다른 재생 기능에 영향 방지)
+      await setAudioModeAsync({ allowsRecording: false });
 
       return uri || null;
     } catch (error) {
       console.error('녹음 중지 오류:', error);
-      Alert.alert('오류', '녹음을 중지할 수 없습니다.');
       return null;
     }
   };
@@ -136,21 +169,18 @@ export const useAudioRecorder = (): UseAudioRecorderReturn => {
    * 녹음 리셋
    */
   const resetRecording = async (): Promise<void> => {
-    if (recording) {
-      try {
-        await recording.stopAndUnloadAsync();
-      } catch (error) {
-        // 정리 오류는 무시 (이미 정리된 상태일 수 있음)
-        console.warn('녹음기 정리 중 오류 (무시됨):', error);
+    try {
+      if (recorderState.isRecording) {
+        await recorder.stop();
       }
+    } catch (e) {
+      // 정리 오류는 무시 (이미 정리된 상태일 수 있음)
     }
-    setRecording(null);
-    setIsRecording(false);
     setRecordingDuration(0);
   };
 
   return {
-    isRecording,
+    isRecording: recorderState.isRecording,
     recordingDuration,
     startRecording,
     stopRecording,

--- a/components/shared/audio-attachment/hooks/useWebAudioRecorder.ts
+++ b/components/shared/audio-attachment/hooks/useWebAudioRecorder.ts
@@ -1,0 +1,145 @@
+/**
+ * components/shared/audio-attachment/hooks/useWebAudioRecorder.ts
+ * 웹 전용 오디오 녹음 Hook (MP3 형식)
+ * 
+ * vmsg 라이브러리 사용하여 브라우저에서 직접 MP3 생성
+ * iOS 호환 가능한 형식으로 녹음
+ */
+
+import { useState, useRef } from 'react';
+import { Alert, Platform } from 'react-native';
+
+interface UseWebAudioRecorderReturn {
+  /** 녹음 중 여부 */
+  isRecording: boolean;
+  /** 녹음 시간 (초) */
+  recordingDuration: number;
+  /** 녹음 시작 */
+  startRecording: () => Promise<void>;
+  /** 녹음 중지 및 로컬 URI 반환 */
+  stopRecording: () => Promise<string | null>;
+  /** 녹음 리셋 */
+  resetRecording: () => Promise<void>;
+}
+
+/**
+ * 웹 전용 오디오 녹음 Hook (MP3 형식)
+ * vmsg 라이브러리를 사용하여 iOS 호환 가능한 MP3 생성
+ */
+export const useWebAudioRecorder = (): UseWebAudioRecorderReturn => {
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordingDuration, setRecordingDuration] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const recorderRef = useRef<any>(null);
+
+  if (Platform.OS !== 'web') {
+    throw new Error('useWebAudioRecorder는 웹 환경에서만 사용 가능합니다.');
+  }
+
+  /**
+   * 녹음 시작
+   */
+  const startRecording = async (): Promise<void> => {
+    if (isRecording) {
+      console.warn('[WebAudioRecorder] 이미 녹음 중입니다.');
+      return;
+    }
+
+    try {
+      // 마이크 권한 요청
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+
+      // vmsg 동적 import (웹 전용)
+      const vmsg = await import('vmsg');
+
+      // 녹음 시작
+      recorderRef.current = new vmsg.default.Recorder({
+        wasmURL: 'https://unpkg.com/vmsg@0.3.0/vmsg.wasm',
+      });
+
+      await recorderRef.current.init();
+      recorderRef.current.startRecording();
+
+      setIsRecording(true);
+      setRecordingDuration(0);
+
+      // 녹음 시간 타이머 시작
+      intervalRef.current = setInterval(() => {
+        setRecordingDuration((prev) => prev + 1);
+      }, 1000);
+
+      console.log('[WebAudioRecorder] 녹음 시작 (MP3 형식)');
+    } catch (error) {
+      console.error('[WebAudioRecorder] 녹음 시작 오류:', error);
+      Alert.alert('오류', '마이크 접근 권한이 필요합니다.');
+    }
+  };
+
+  /**
+   * 녹음 중지 및 MP3 Blob URL 반환
+   */
+  const stopRecording = async (): Promise<string | null> => {
+    if (!isRecording || !recorderRef.current) {
+      console.warn('[WebAudioRecorder] 녹음 중이 아닙니다.');
+      return null;
+    }
+
+    try {
+      // 타이머 정지
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+
+      // 녹음 중지 및 MP3 Blob 생성
+      const blob = await recorderRef.current.stopRecording();
+      setIsRecording(false);
+
+      // Blob을 URL로 변환
+      const url = URL.createObjectURL(blob);
+
+      console.log('[WebAudioRecorder] 녹음 완료 (MP3)');
+      console.log('  - Blob 크기:', blob.size, 'bytes');
+      console.log('  - MIME 타입:', blob.type);
+      console.log('  - URL:', url);
+
+      return url;
+    } catch (error) {
+      console.error('[WebAudioRecorder] 녹음 중지 오류:', error);
+      setIsRecording(false);
+      return null;
+    }
+  };
+
+  /**
+   * 녹음 리셋
+   */
+  const resetRecording = async (): Promise<void> => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    if (recorderRef.current) {
+      try {
+        if (isRecording) {
+          await recorderRef.current.stopRecording();
+        }
+      } catch (error) {
+        // 정리 오류 무시
+      }
+      recorderRef.current = null;
+    }
+
+    setIsRecording(false);
+    setRecordingDuration(0);
+  };
+
+  return {
+    isRecording,
+    recordingDuration,
+    startRecording,
+    stopRecording,
+    resetRecording,
+  };
+};

--- a/components/shared/audio-attachment/index.tsx
+++ b/components/shared/audio-attachment/index.tsx
@@ -22,7 +22,7 @@ import { formatTime, formatTimeFromMillis } from '@/utils/format';
 import { getMimeTypes } from '@/utils';
 import * as DocumentPicker from 'expo-document-picker';
 import React, { useEffect, useState } from 'react';
-import { Alert, Pressable, Text, View } from 'react-native';
+import { Alert, Platform, Pressable, Text, View } from 'react-native';
 import Icon from 'react-native-remix-icon';
 import { useAudioPreview } from './hooks/useAudioPreview';
 import { useAudioRecorder } from './hooks/useAudioRecorder';
@@ -51,14 +51,18 @@ export const AudioAttachment: React.FC<AudioAttachmentProps> = ({
   const [selectedAudioUri, setSelectedAudioUri] = useState<string | null>(null);
   const [selectedAudioName, setSelectedAudioName] = useState<string>('');
 
-  // 녹음 Hook
+  // 녹음 Hook (플랫폼별 분기)
+  // 웹: useWebAudioRecorder (MP3), 네이티브: useAudioRecorder (m4a)
+  const nativeRecorder = useAudioRecorder();
+  const webRecorder = Platform.OS === 'web' ? require('./hooks/useWebAudioRecorder').useWebAudioRecorder() : null;
+  
   const {
     isRecording,
     recordingDuration,
     startRecording,
     stopRecording: stopRecordingHook,
     resetRecording,
-  } = useAudioRecorder();
+  } = Platform.OS === 'web' ? webRecorder : nativeRecorder;
 
   // 미리보기 Hook
   const {
@@ -91,8 +95,19 @@ export const AudioAttachment: React.FC<AudioAttachmentProps> = ({
   const handleStopRecording = async () => {
     const uri = await stopRecordingHook();
     if (uri) {
+      // 플랫폼별 확장자 설정
+      // 웹: mp3 (vmsg 사용), 네이티브: m4a (expo-audio 사용)
+      const extension = Platform.OS === 'web' ? 'mp3' : 'm4a';
+      
+      if (__DEV__) {
+        console.log('[AudioAttachment] 녹음 파일 정보:');
+        console.log('  - Platform:', Platform.OS);
+        console.log('  - URI:', uri);
+        console.log('  - 형식:', extension);
+      }
+      
       setSelectedAudioUri(uri);
-      setSelectedAudioName(`recording_${Date.now()}.m4a`);
+      setSelectedAudioName(`recording_${Date.now()}.${extension}`);
     }
   };
 

--- a/components/shared/audio-player/hooks/useAudioPlayer.ts
+++ b/components/shared/audio-player/hooks/useAudioPlayer.ts
@@ -3,10 +3,17 @@
  * 오디오 플레이어 비즈니스 로직
  *
  * 미디어 ID 또는 URL을 받아서, URL이면 그대로 사용하고 ID면 URL로 변환한 후 오디오 재생 상태를 관리합니다.
+ * expo-audio 사용 (expo-av에서 마이그레이션)
  */
 
-import { Audio } from 'expo-av';
+import {
+  setAudioModeAsync,
+  useAudioPlayerStatus,
+  useAudioPlayer as useExpoAudioPlayer,
+} from 'expo-audio';
+import * as FileSystem from 'expo-file-system/legacy';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { Platform } from 'react-native';
 import { useSharedValue } from 'react-native-reanimated';
 
 import { getMediaUrl } from '@/utils';
@@ -20,6 +27,104 @@ const isUrl = (value: string): boolean => {
   return value.startsWith('http://') || value.startsWith('https://') || value.startsWith('data:');
 };
 
+/**
+ * Base64 문자열인지 확인
+ */
+const isBase64DataUri = (value: string): boolean => {
+  return value.startsWith('data:audio/') && value.includes('base64,');
+};
+
+/**
+ * iOS에서 지원하지 않는 오디오 형식인지 확인
+ */
+const isUnsupportedFormatOnIOS = (value: string): boolean => {
+  if (Platform.OS !== 'ios') return false;
+
+  // webm, ogg 등 iOS에서 지원하지 않는 형식
+  const unsupportedFormats = ['webm', 'ogg', 'opus', 'wav'];
+
+  // URL에서 확장자 확인 (쿼리 파라미터 제거 후)
+  const urlWithoutQuery = value.split('?')[0];
+  if (urlWithoutQuery.includes('.')) {
+    const extension = urlWithoutQuery.split('.').pop()?.toLowerCase() || '';
+    if (unsupportedFormats.includes(extension)) return true;
+  }
+
+  // MIME 타입 확인 (data:audio/webm;... 형식)
+  const mimeMatch = value.match(/data:audio\/([^;,]+)/);
+  if (mimeMatch) {
+    const mimeType = mimeMatch[1].toLowerCase();
+    if (unsupportedFormats.some((format) => mimeType.includes(format))) return true;
+  }
+
+  return false;
+};
+
+/**
+ * 서버 URL의 Content-Type을 확인하여 iOS에서 재생 가능한지 체크
+ */
+const checkAudioCompatibility = async (url: string): Promise<boolean> => {
+  if (Platform.OS !== 'ios') return true;
+
+  try {
+    // HEAD 요청으로 Content-Type만 확인
+    const response = await fetch(url, { method: 'HEAD' });
+    const contentType = response.headers.get('content-type') || '';
+
+    const unsupportedTypes = ['webm', 'ogg', 'opus', 'wav'];
+    const isUnsupported = unsupportedTypes.some((type) => contentType.toLowerCase().includes(type));
+
+    if (__DEV__) {
+      console.log('[AudioPlayer] Content-Type:', contentType, 'iOS 호환:', !isUnsupported);
+    }
+
+    return !isUnsupported;
+  } catch (error) {
+    // 네트워크 오류 등의 경우 일단 시도해보도록 true 반환
+    if (__DEV__) {
+      console.warn('[AudioPlayer] Content-Type 확인 실패, 재생 시도:', error);
+    }
+    return true;
+  }
+};
+
+/**
+ * Base64 문자열을 로컬 파일로 저장 (iOS에서 긴 Base64 문자열 처리)
+ */
+const saveBase64ToLocalFile = async (base64String: string): Promise<string> => {
+  // Base64 문자열에서 헤더 제거 (data:audio/m4a;base64, 부분)
+  const base64Data = base64String.includes('base64,')
+    ? base64String.split('base64,')[1]
+    : base64String;
+
+  // 확장자 추출 (data:audio/m4a;base64, -> m4a)
+  let extension = 'm4a'; // 기본값
+  const mimeMatch = base64String.match(/data:audio\/([^;]+)/);
+  if (mimeMatch) {
+    const mimeType = mimeMatch[1];
+    // MIME 타입을 확장자로 변환
+    if (mimeType.includes('m4a') || mimeType.includes('mp4')) extension = 'm4a';
+    else if (mimeType.includes('mp3') || mimeType.includes('mpeg')) extension = 'mp3';
+    else if (mimeType.includes('aac')) extension = 'aac';
+    else if (mimeType.includes('webm')) extension = 'webm';
+  }
+
+  // 임시 디렉토리에 파일 저장 경로 생성
+  const fileName = `temp_audio_${Date.now()}.${extension}`;
+  const fileUri = `${FileSystem.cacheDirectory}${fileName}`;
+
+  // Base64 데이터를 실제 파일로 쓰기
+  await FileSystem.writeAsStringAsync(fileUri, base64Data, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+
+  if (__DEV__) {
+    console.log('[AudioPlayer] Base64를 로컬 파일로 저장 완료:', fileUri);
+  }
+
+  return fileUri;
+};
+
 export interface UseAudioPlayerReturn {
   // 상태
   isLoading: boolean;
@@ -29,6 +134,7 @@ export interface UseAudioPlayerReturn {
   progress: number;
   progressValue: ReturnType<typeof useSharedValue<number>>;
   hasAudio: boolean;
+  error: Error | null;
 
   // 핸들러
   handleTogglePlay: () => Promise<void>;
@@ -48,37 +154,38 @@ export const useAudioPlayer = ({
   // 오디오 URL 상태
   const [url, setUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-
-  // 재생 상태
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [positionMillis, setPositionMillis] = useState(0);
-  const [durationMillis, setDurationMillis] = useState(0);
-  const soundRef = useRef<Audio.Sound | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const localFileUriRef = useRef<string | null>(null); // Base64에서 변환된 로컬 파일 경로
 
   // mediaId가 URL인지 ID인지 판단하여 URL로 변환
   useEffect(() => {
     if (!mediaId) {
       setUrl(null);
+      setError(null);
       return;
     }
 
     // 이미 URL이면 그대로 사용
     if (isUrl(mediaId)) {
       setUrl(mediaId);
+      setError(null);
       return;
     }
 
     // ID인 경우 URL로 변환
     const convertMediaId = async () => {
       setIsLoading(true);
+      setError(null);
       try {
         const convertedUrl = await getMediaUrl(mediaId);
         setUrl(convertedUrl);
+        setError(null);
       } catch (error) {
         const err = error instanceof Error ? error : new Error('미디어 URL 변환 실패');
         if (__DEV__) {
           console.error('[AudioPlayer] 미디어 URL 변환 실패:', err);
         }
+        setError(err);
         onError?.(err);
         setUrl(null);
       } finally {
@@ -89,92 +196,146 @@ export const useAudioPlayer = ({
     convertMediaId();
   }, [mediaId, onError]);
 
-  // 오디오 로드 및 재생 상태 관리
+  // 오디오 모드 설정 (iOS 무음 모드에서도 재생하기 위해 필수)
+  useEffect(() => {
+    const configureAudio = async () => {
+      try {
+        await setAudioModeAsync({
+          allowsRecording: false,
+          playsInSilentMode: true, // 무음 모드에서도 소리 재생
+          shouldPlayInBackground: false,
+          interruptionMode: 'doNotMix',
+        });
+      } catch (error) {
+        if (__DEV__) {
+          console.error('[AudioPlayer] 오디오 모드 설정 실패:', error);
+        }
+      }
+    };
+
+    configureAudio();
+  }, []);
+
+  // Base64 문자열인 경우 iOS에서 로컬 파일로 변환
+  const [audioSource, setAudioSource] = useState<string | null>(null);
   useEffect(() => {
     if (!url) {
-      // URL이 없으면 기존 Sound 객체 정리
-      if (soundRef.current) {
-        soundRef.current.unloadAsync().catch(console.error);
-        soundRef.current = null;
+      setAudioSource(null);
+      // 로컬 파일 정리
+      if (localFileUriRef.current) {
+        FileSystem.deleteAsync(localFileUriRef.current, { idempotent: true }).catch(console.error);
+        localFileUriRef.current = null;
       }
-      setIsPlaying(false);
-      setPositionMillis(0);
-      setDurationMillis(0);
       return;
     }
 
-    const loadSound = async () => {
+    const processUrl = async () => {
       try {
-        // 기존 Sound 객체가 있으면 정리
-        if (soundRef.current) {
-          await soundRef.current.unloadAsync();
+        setIsLoading(true);
+        setError(null);
+
+        // 1단계: URL 확장자로 먼저 체크
+        if (isUnsupportedFormatOnIOS(url)) {
+          const unsupportedError = new Error(
+            'iOS에서 지원하지 않는 오디오 형식입니다. 웹에서 녹음된 파일은 iOS에서 재생할 수 없습니다.',
+          );
+          if (__DEV__) {
+            console.error('[AudioPlayer] iOS 미지원 형식 (URL 확장자):', url);
+          }
+          setError(unsupportedError);
+          onError?.(unsupportedError);
+          setAudioSource(null);
+          setIsLoading(false);
+          return;
         }
 
-        // 새로운 Sound 객체 생성
-        const { sound } = await Audio.Sound.createAsync(
-          { uri: url },
-          { shouldPlay: false },
-          (status) => {
-            if (status.isLoaded) {
-              setPositionMillis(status.positionMillis || 0);
-              setDurationMillis(status.durationMillis || 0);
-
-              // 재생 완료 시
-              if (status.didJustFinish) {
-                setIsPlaying(false);
-                setPositionMillis(0);
-                onPlayStateChange?.(false);
-              }
+        // 2단계: 서버 URL인 경우 Content-Type 체크 (http/https로 시작하는 경우만)
+        if (Platform.OS === 'ios' && (url.startsWith('http://') || url.startsWith('https://'))) {
+          const isCompatible = await checkAudioCompatibility(url);
+          if (!isCompatible) {
+            const unsupportedError = new Error(
+              'iOS에서 지원하지 않는 오디오 형식입니다. 웹에서 녹음된 파일은 iOS에서 재생할 수 없습니다.',
+            );
+            if (__DEV__) {
+              console.error('[AudioPlayer] iOS 미지원 형식 (Content-Type):', url);
             }
-          },
-        );
-
-        soundRef.current = sound;
-
-        // 초기 duration 가져오기
-        const status = await sound.getStatusAsync();
-        if (status.isLoaded) {
-          setDurationMillis(status.durationMillis || 0);
+            setError(unsupportedError);
+            onError?.(unsupportedError);
+            setAudioSource(null);
+            setIsLoading(false);
+            return;
+          }
         }
+
+        // 3단계: Base64 문자열인 경우 iOS에서 로컬 파일로 저장
+        let finalUrl = url;
+        if (isBase64DataUri(url) && Platform.OS === 'ios') {
+          if (__DEV__) {
+            console.log('[AudioPlayer] iOS: Base64 문자열 감지, 로컬 파일로 변환 중...');
+          }
+          finalUrl = await saveBase64ToLocalFile(url);
+          localFileUriRef.current = finalUrl; // 나중에 정리하기 위해 저장
+        }
+
+        setAudioSource(finalUrl);
       } catch (error) {
-        const err = error instanceof Error ? error : new Error('오디오 로드 실패');
+        const err = error instanceof Error ? error : new Error('오디오 URL 처리 실패');
         if (__DEV__) {
-          console.error('[AudioPlayer] 오디오 로드 오류:', err);
+          console.error('[AudioPlayer] 오디오 URL 처리 오류:', error);
         }
+        setError(err);
         onError?.(err);
+        setAudioSource(null);
+      } finally {
+        setIsLoading(false);
       }
     };
 
-    loadSound();
+    processUrl();
+  }, [url, onError]);
 
-    // 정리 함수
-    return () => {
-      if (soundRef.current) {
-        soundRef.current.unloadAsync().catch(console.error);
-        soundRef.current = null;
+  // expo-audio의 useAudioPlayer hook 사용
+  const player = useExpoAudioPlayer(audioSource, {
+    updateInterval: 100, // 더 촘촘한 업데이트
+  });
+
+  // 재생 상태 구독
+  const status = useAudioPlayerStatus(player);
+
+  // 상태 동기화 및 에러 처리
+  useEffect(() => {
+    if (!status.isLoaded) {
+      // 로딩 중이거나 에러 상태
+      if (__DEV__) {
+        console.log('[AudioPlayer] 상태:', {
+          isLoaded: status.isLoaded,
+          isBuffering: status.isBuffering,
+        });
       }
-    };
-  }, [url, onError, onPlayStateChange]);
+      return;
+    }
+
+    // 재생 완료 시
+    if (status.didJustFinish) {
+      player.seekTo(0); // 재생바 초기화
+      onPlayStateChange?.(false);
+    }
+  }, [status, player, onPlayStateChange]);
+
+  // 에러 처리 - 재생 실패 시 handleTogglePlay의 catch 블록에서 처리됨
 
   // 재생/일시정지 토글
   const handleTogglePlay = async () => {
-    if (!soundRef.current) {
+    if (!player || !status.isLoaded) {
       return;
     }
 
     try {
-      const status = await soundRef.current.getStatusAsync();
-      if (!status.isLoaded) {
-        return;
-      }
-
-      if (status.isPlaying) {
-        await soundRef.current.pauseAsync();
-        setIsPlaying(false);
+      if (status.playing) {
+        player.pause();
         onPlayStateChange?.(false);
       } else {
-        await soundRef.current.playAsync();
-        setIsPlaying(true);
+        player.play();
         onPlayStateChange?.(true);
       }
     } catch (error) {
@@ -182,18 +343,21 @@ export const useAudioPlayer = ({
       if (__DEV__) {
         console.error('[AudioPlayer] 재생 토글 오류:', err);
       }
+      setError(err);
       onError?.(err);
     }
   };
 
   // 재생 상태가 변경될 때 콜백 호출
   useEffect(() => {
-    onPlayStateChange?.(isPlaying);
-  }, [isPlaying, onPlayStateChange]);
+    if (status.isLoaded) {
+      onPlayStateChange?.(status.playing);
+    }
+  }, [status.playing, status.isLoaded, onPlayStateChange]);
 
   // progress 계산 (초 단위로 변환)
-  const currentTime = useMemo(() => positionMillis / 1000, [positionMillis]);
-  const duration = useMemo(() => durationMillis / 1000, [durationMillis]);
+  const currentTime = useMemo(() => status.currentTime || 0, [status.currentTime]);
+  const duration = useMemo(() => status.duration || 0, [status.duration]);
   const progress = useMemo(
     () => (duration > 0 ? currentTime / duration : 0),
     [currentTime, duration],
@@ -213,17 +377,32 @@ export const useAudioPlayer = ({
     [progress],
   );
 
+  // 로딩 상태는 status.isBuffering 또는 !status.isLoaded로 판단
+  const isLoadingState = isLoading || (!status.isLoaded && audioSource !== null);
+
   // 오디오 존재 여부
   const hasAudio = Boolean(mediaId);
 
+  // 정리 함수
+  useEffect(() => {
+    return () => {
+      // 로컬 파일 정리
+      if (localFileUriRef.current) {
+        FileSystem.deleteAsync(localFileUriRef.current, { idempotent: true }).catch(console.error);
+        localFileUriRef.current = null;
+      }
+    };
+  }, []);
+
   return {
-    isLoading,
-    isPlaying,
+    isLoading: isLoadingState,
+    isPlaying: status.playing || false,
     currentTime,
     duration,
     progress,
     progressValue,
     hasAudio,
+    error,
     handleTogglePlay,
     progressBarStyle,
   };

--- a/components/shared/audio-player/index.tsx
+++ b/components/shared/audio-player/index.tsx
@@ -19,8 +19,15 @@ import type { AudioPlayerProps } from './types';
 
 export const AudioPlayer: React.FC<AudioPlayerProps> = (props) => {
   // 비즈니스 로직은 hook에서 처리
-  const { isLoading, isPlaying, currentTime, progressValue, hasAudio, handleTogglePlay } =
-    useAudioPlayer(props);
+  const {
+    isLoading,
+    isPlaying,
+    currentTime,
+    progressValue,
+    hasAudio,
+    error,
+    handleTogglePlay,
+  } = useAudioPlayer(props);
 
   // 동적 width를 위한 animated style
   const progressBarStyle = useAnimatedStyle(() => ({
@@ -37,6 +44,18 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = (props) => {
   // mediaId가 없거나 로딩 중이면 렌더링하지 않음
   if (!hasAudio) {
     return null;
+  }
+
+  // 에러 발생 시 에러 UI 표시
+  if (error) {
+    return (
+      <View style={styles.audioErrorContainer}>
+        <View style={styles.audioErrorIconContainer}>
+          <Icon name="error-warning-line" size={20} color={Colors.grey[500]} />
+        </View>
+        <Text style={styles.audioErrorText}>오디오 파일을 재생할 수 없습니다</Text>
+      </View>
+    );
   }
 
   return (

--- a/components/shared/audio-player/styles.ts
+++ b/components/shared/audio-player/styles.ts
@@ -66,5 +66,37 @@ export const styles = StyleSheet.create({
     ...Typography.body.body8,
     color: Colors.grey[600],
   },
+
+  // 오디오 에러 컨테이너
+  audioErrorContainer: {
+    width: '100%',
+    paddingVertical: Spacing.lg, // 24px
+    paddingHorizontal: Spacing.md, // 16px
+    backgroundColor: Colors.whiteGrey[100],
+    borderRadius: BorderRadius.lg,
+    borderWidth: 2,
+    borderColor: Colors.whiteGrey[300],
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.sm, // 8px
+    minHeight: 83, // 플레이어와 동일한 높이
+  },
+
+  // 오디오 에러 아이콘 컨테이너
+  audioErrorIconContainer: {
+    width: 40,
+    height: 40,
+    borderRadius: BorderRadius.full,
+    backgroundColor: Colors.whiteGrey[200],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // 오디오 에러 텍스트
+  audioErrorText: {
+    ...Typography.body.body11,
+    color: Colors.grey[600],
+    textAlign: 'center',
+  },
 });
 

--- a/components/shared/video-player/hooks/useVideoPlayer.ts
+++ b/components/shared/video-player/hooks/useVideoPlayer.ts
@@ -81,6 +81,7 @@ export interface UseVideoPlayerReturn {
   hasVideo: boolean;
   thumbnailUri: string | null;
   showControls: boolean;
+  error: Error | null;
 
   // 핸들러
   handleTogglePlay: () => void;
@@ -102,6 +103,7 @@ export const useVideoPlayer = ({
 }: VideoPlayerProps): UseVideoPlayerReturn => {
   const [url, setUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
   const [thumbnailUri, setThumbnailUri] = useState<string | null>(thumbnailUrl || null);
   const [showControls, setShowControls] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -255,26 +257,31 @@ export const useVideoPlayer = ({
 
     if (!mediaId) {
       setUrl(null);
+      setError(null);
       return;
     }
 
     // 이미 URL이면 그대로 사용
     if (isUrl(mediaId)) {
       setUrl(mediaId);
+      setError(null);
       return;
     }
 
     // ID인 경우 URL로 변환
     const convertMediaId = async () => {
       setIsLoading(true);
+      setError(null);
       try {
         const convertedUrl = await getMediaUrl(mediaId);
         setUrl(convertedUrl);
+        setError(null);
       } catch (error) {
         const err = error instanceof Error ? error : new Error('미디어 URL 변환 실패');
         if (__DEV__) {
           console.error('[VideoPlayer] 미디어 URL 변환 실패:', err);
         }
+        setError(err);
         onError?.(err);
         setUrl(null);
       } finally {
@@ -342,10 +349,12 @@ export const useVideoPlayer = ({
         onPlayStateChange?.(true);
       }
     } catch (error) {
+      const err = error instanceof Error ? error : new Error('재생 토글 실패');
       if (__DEV__) {
-        console.error('[VideoPlayer] 재생 토글 오류:', error);
+        console.error('[VideoPlayer] 재생 토글 오류:', err);
       }
-      onError?.(error instanceof Error ? error : new Error('재생 토글 실패'));
+      setError(err);
+      onError?.(err);
     }
   }, [player, url, onError, onPlayStateChange]);
 
@@ -418,6 +427,7 @@ export const useVideoPlayer = ({
     hasVideo,
     thumbnailUri,
     showControls,
+    error,
     handleTogglePlay,
     handleSeek,
     handleToggleControls,

--- a/components/shared/video-player/index.tsx
+++ b/components/shared/video-player/index.tsx
@@ -116,6 +116,7 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = (props) => {
     hasVideo,
     thumbnailUri,
     showControls,
+    error,
     handleTogglePlay,
     handleToggleControls,
     handleSeek,
@@ -132,6 +133,20 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = (props) => {
   // mediaId가 없거나 로딩 중이면 렌더링하지 않음
   if (!hasVideo) {
     return null;
+  }
+
+  // 에러 발생 시 에러 UI 표시
+  if (error) {
+    return (
+      <View style={[styles.videoPlayerContainer, props.containerStyle]}>
+        <View style={styles.videoErrorContainer}>
+          <View style={styles.videoErrorIconContainer}>
+            <Icon name="error-warning-line" size={24} color={Colors.grey[500]} />
+          </View>
+          <Text style={styles.videoErrorText}>비디오 파일을 재생할 수 없습니다</Text>
+        </View>
+      </View>
+    );
   }
 
   return (

--- a/components/shared/video-player/styles.ts
+++ b/components/shared/video-player/styles.ts
@@ -106,4 +106,36 @@ export const styles = StyleSheet.create({
     ...Typography.body.body8,
     color: Colors.grey[600],
   },
+
+  // 비디오 에러 컨테이너
+  videoErrorContainer: {
+    width: '100%',
+    aspectRatio: 16 / 9, // 비디오와 동일한 비율
+    paddingVertical: Spacing.xl, // 32px
+    paddingHorizontal: Spacing.md, // 16px
+    backgroundColor: Colors.whiteGrey[100],
+    borderRadius: BorderRadius.lg,
+    borderWidth: 2,
+    borderColor: Colors.whiteGrey[300],
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.sm, // 8px
+  },
+
+  // 비디오 에러 아이콘 컨테이너
+  videoErrorIconContainer: {
+    width: 48,
+    height: 48,
+    borderRadius: BorderRadius.full,
+    backgroundColor: Colors.whiteGrey[200],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // 비디오 에러 텍스트
+  videoErrorText: {
+    ...Typography.body.body11,
+    color: Colors.grey[600],
+    textAlign: 'center',
+  },
 });

--- a/components/timecapsule-create/components/step-room/hooks/useParticipants.ts
+++ b/components/timecapsule-create/components/step-room/hooks/useParticipants.ts
@@ -3,6 +3,7 @@
  * 참여자 목록 관리,상태 관리, 작성 내용 저장 Hook
  */
 
+import { MIME_TYPE_MAP } from '@/commons/constants/media';
 import { STORAGE_KEYS } from '@/commons/constants/storage';
 import { getUserFromToken } from '@/utils/auth';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -494,30 +495,21 @@ export function useParticipants({
 
   /**
    * URI에서 파일 확장자를 추출하여 MIME 타입 반환
+   * MIME_TYPE_MAP을 사용하되, 매핑이 없으면 기본값 반환
    */
   const getMimeType = (uri: string, mediaType: 'image' | 'audio' | 'video'): string => {
-    const extension = uri.split('.').pop()?.toLowerCase() || '';
+    const extension = uri.split('.').pop()?.split('?')[0].toLowerCase() || '';
+    
+    const mimeType = MIME_TYPE_MAP[extension];
 
-    if (mediaType === 'image') {
-      if (extension === 'jpg' || extension === 'jpeg') return 'image/jpeg';
-      if (extension === 'png') return 'image/png';
-      if (extension === 'gif') return 'image/gif';
-      return 'image/jpeg'; // 기본값
+    if (mimeType) {
+      return mimeType;
     }
 
-    if (mediaType === 'audio') {
-      if (extension === 'mp3') return 'audio/mpeg';
-      if (extension === 'm4a') return 'audio/mp4';
-      if (extension === 'wav') return 'audio/wav';
-      return 'audio/mpeg'; // 기본값
-    }
-
-    if (mediaType === 'video') {
-      if (extension === 'mp4') return 'video/mp4';
-      if (extension === 'mov') return 'video/quicktime';
-      if (extension === 'avi') return 'video/x-msvideo';
-      return 'video/mp4'; // 기본값
-    }
+    // 매핑이 없는 경우 기본값 반환 (백엔드 허용 형식)
+    if (mediaType === 'image') return 'image/jpeg';
+    if (mediaType === 'audio') return 'audio/m4a'; // 기본값을 m4a로 변경
+    if (mediaType === 'video') return 'video/mp4';
 
     return 'application/octet-stream';
   };

--- a/components/timecapsule-create/components/write-bottomsheet/hooks/useSubmitContent.ts
+++ b/components/timecapsule-create/components/write-bottomsheet/hooks/useSubmitContent.ts
@@ -166,22 +166,44 @@ export function useSubmitContent(): UseSubmitContentReturn {
         if (isLocalFile(data.music)) {
           setUploadProgress('음악 파일 추가 중...');
           console.log('📤 [useSubmitContent] 음악 파일 추가 중...');
-          const fileName = generateFileName(data.music, 'music', 'mp3');
+          
+          // URI에서 확장자 추출
+          let extension = 'm4a'; // 기본값 (모든 플랫폼에서 m4a로 녹음)
+          const uriParts = data.music.split('.');
+          if (uriParts.length > 1) {
+            const extractedExt = uriParts[uriParts.length - 1].split('?')[0].toLowerCase();
+            // 백엔드 허용 형식만 체크
+            if (['m4a', 'mp3', 'aac', 'mpeg', 'mp4'].includes(extractedExt)) {
+              extension = extractedExt;
+            }
+          }
+          
+          const fileName = generateFileName(data.music, 'music', extension);
+          
+          // 확장자에 따른 MIME 타입 결정 (백엔드 허용 형식만)
+          const mimeTypeMap: Record<string, string> = {
+            'm4a': 'audio/m4a',
+            'mp3': 'audio/mpeg',
+            'mpeg': 'audio/mpeg',
+            'mp4': 'audio/mp4',
+            'aac': 'audio/aac',
+          };
+          const mimeType = mimeTypeMap[extension] || 'audio/m4a';
 
           // ⭐ 플랫폼별 분기 처리
           if (Platform.OS === 'web') {
             // 웹: URI를 Blob으로 변환 후 추가
             const blob = await uriToBlob(data.music);
             formData.append('music', blob, fileName);
-            console.log(`✅ [useSubmitContent] [웹] 음악 파일 추가 완료: ${fileName}`);
+            console.log(`✅ [useSubmitContent] [웹] 음악 파일 추가 완료: ${fileName} (${mimeType})`);
           } else {
             // React Native: { uri, type, name } 형태로 추가
             formData.append('music', {
               uri: data.music,
-              type: 'audio/mpeg',
+              type: mimeType,
               name: fileName,
             } as any);
-            console.log(`✅ [useSubmitContent] [앱] 음악 파일 추가 완료: ${fileName}`);
+            console.log(`✅ [useSubmitContent] [앱] 음악 파일 추가 완료: ${fileName} (${mimeType})`);
           }
         } else {
           console.log('  ⏭️  음악: 이미 업로드된 파일이므로 건너뜀 - ', data.music);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "axios": "^1.13.2",
         "dayjs": "^1.11.19",
         "expo": "~54.0.29",
-        "expo-av": "~16.0.8",
+        "expo-audio": "~1.1.1",
         "expo-build-properties": "^1.0.10",
         "expo-constants": "~18.0.12",
         "expo-document-picker": "^14.0.8",
@@ -53,7 +53,8 @@
         "react-native-svg": "^15.15.1",
         "react-native-web": "~0.21.0",
         "react-native-webview": "^13.16.0",
-        "react-native-worklets": "0.5.1"
+        "react-native-worklets": "0.5.1",
+        "vmsg": "^0.4.0"
       },
       "devDependencies": {
         "@react-native-community/cli": "^20.1.0",
@@ -7422,20 +7423,16 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-av": {
-      "version": "16.0.8",
-      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-16.0.8.tgz",
-      "integrity": "sha512-cmVPftGR/ca7XBgs7R6ky36lF3OC0/MM/lpgX/yXqfv0jASTsh7AYX9JxHCwFmF+Z6JEB1vne9FDx4GiLcGreQ==",
+    "node_modules/expo-audio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-1.1.1.tgz",
+      "integrity": "sha512-CPCpJ+0AEHdzWROc0f00Zh6e+irLSl2ALos/LPvxEeIcJw1APfBa4DuHPkL4CQCWsVe7EnUjFpdwpqsEUWcP0g==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
+        "expo-asset": "*",
         "react": "*",
-        "react-native": "*",
-        "react-native-web": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-web": {
-          "optional": true
-        }
+        "react-native": "*"
       }
     },
     "node_modules/expo-build-properties": {
@@ -15303,6 +15300,12 @@
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "license": "MIT"
+    },
+    "node_modules/vmsg": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/vmsg/-/vmsg-0.4.0.tgz",
+      "integrity": "sha512-46BBqRSfqdFGUpO2j+Hpz8T9YE5uWG0/PWal1PT+R1o8NEthtjG/XWl4HzbB8hIHpg/UtmKvsxL2OKQBrIYcHQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "axios": "^1.13.2",
     "dayjs": "^1.11.19",
     "expo": "~54.0.29",
-    "expo-av": "~16.0.8",
+    "expo-audio": "~1.1.1",
     "expo-build-properties": "^1.0.10",
     "expo-constants": "~18.0.12",
     "expo-document-picker": "^14.0.8",
@@ -57,7 +57,8 @@
     "react-native-svg": "^15.15.1",
     "react-native-web": "~0.21.0",
     "react-native-webview": "^13.16.0",
-    "react-native-worklets": "0.5.1"
+    "react-native-worklets": "0.5.1",
+    "vmsg": "^0.4.0"
   },
   "devDependencies": {
     "@react-native-community/cli": "^20.1.0",

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -6,6 +6,8 @@
 export * from './addressFormat';
 export * from './api';
 export * from './apiClient';
+// audioConverter는 웹 전용이므로 동적 import로만 사용
+// export * from './audioConverter';
 export * from './auth';
 export * from './coordinate';
 export * from './date-price';

--- a/utils/mediaUrl.ts
+++ b/utils/mediaUrl.ts
@@ -24,6 +24,14 @@ export const getMediaUrl = async (mediaId: string): Promise<string> => {
     buildApiUrl(apiBaseUrl, `${API_ENDPOINTS.MEDIA.URL}/${mediaId}/url`),
   );
 
+  // 응답에서 url 필드 추출
+  if (!response.data || !response.data.url) {
+    if (__DEV__) {
+      console.error('[getMediaUrl] 응답 데이터 구조 오류:', response.data);
+    }
+    throw new Error('미디어 URL을 가져올 수 없습니다. 응답 형식이 올바르지 않습니다.');
+  }
+
   return response.data.url;
 };
 
@@ -40,9 +48,7 @@ export const getMediaUrls = async (mediaIds: string[]): Promise<string[]> => {
  * @param url 검사할 URL (string | null | undefined)
  * @returns 유효한 URL인지 여부
  */
-export const isValidImageUrl = (
-  url: string | null | undefined,
-): url is string => {
+export const isValidImageUrl = (url: string | null | undefined): url is string => {
   return (
     url !== undefined &&
     url !== null &&


### PR DESCRIPTION
## 📌 관련 이슈 (Task ID)

- ID: 플랫폼별 오디오 녹음 및 재생 호환성 개선

## 📝 작업 내용 (Details)

- [x] iOS/Android에서 m4a 형식으로 오디오 녹음 (expo-audio 사용)
- [x] 웹에서 MP3 형식으로 오디오 녹음 (vmsg 라이브러리 사용)
- [x] iOS에서 webm 파일 재생 불가 문제 해결
- [x] 백엔드 허용 형식(m4a, mp3, aac)에 맞춘 화이트리스트 적용
- [x] 플랫폼별 MIME 타입 자동 설정
- [x] 웹 번들에만 vmsg 포함 (네이티브 앱 용량 영향 없음)
- [x] 탭 바 높이를 84px로 변경
- [x] 모달 높이를 콘텐츠에 맞게 자동 조정
- [x] my-egg-list 아이템 날짜 텍스트 오버플로우 수정 및 워딩 제거
- [x] 이스터에그 모달 스크롤 동작 수정

## 🧐 리뷰 포인트 (Review Point)

- **BREAKING CHANGE**: 오디오 녹음 형식이 플랫폼별로 다르게 설정됨
  - iOS/Android: m4a 형식
  - 웹: MP3 형식 (vmsg 라이브러리 사용)
- iOS에서 webm 파일 재생 시도 시 명확한 에러 메시지 표시
- 플랫폼별 오디오 호환성 체크 로직 추가 (URL 확장자 및 Content-Type 확인)
- Base64 오디오 데이터를 iOS에서 로컬 파일로 변환하여 재생 지원

## ✅ 체크리스트 (Checklist)

- [x] 컨벤션(커밋, 브랜치 네이밍)을 준수했나요?
- [x] 불필요한 콘솔 로그(console.log)나 주석을 제거했나요?
- [x] 실행 시 에러가 발생하지 않나요?

## 📦 변경된 파일

### 주요 변경사항
- `components/shared/audio-attachment/hooks/useAudioRecorder.ts`: 플랫폼별 녹음 형식 분기 처리
- `components/shared/audio-attachment/hooks/useWebAudioRecorder.ts`: 웹 전용 MP3 녹음 훅 추가
- `components/shared/audio-player/hooks/useAudioPlayer.ts`: iOS 호환성 체크 및 Base64 처리 로직 추가
- `commons/constants/media.ts`: 백엔드 허용 형식 화이트리스트 적용
- `app.config.js`: 웹 번들에만 vmsg 포함 설정
- `package.json`: vmsg 라이브러리 추가

### 기타 변경사항
- 탭 바 높이 조정
- 모달 높이 자동 조정
- my-egg-list UI 개선
- 이스터에그 모달 스크롤 동작 수정
