### PR TITLE
feat: 지도 초기 로딩 시 스피너 추가 및 빈 화면 문제 해결

### DIFF
--- a/commons/components/spinner/index.tsx
+++ b/commons/components/spinner/index.tsx
@@ -1,0 +1,24 @@
+/**
+ * Spinner Component
+ * Version: 1.0.0
+ * Created: 2025-01-11
+ *
+ * [Pure UI Component] 로딩 스피너
+ * - 전역적으로 사용 가능한 로딩 인디케이터
+ */
+
+import React from 'react';
+import { ActivityIndicator, View } from 'react-native';
+
+import { styles } from './styles';
+import type { SpinnerProps } from './types';
+
+export function Spinner({ size = 'large', color, fullScreen = false }: SpinnerProps = {}) {
+  const containerStyle = fullScreen ? styles.fullScreenContainer : styles.container;
+
+  return (
+    <View style={containerStyle}>
+      <ActivityIndicator size={size} color={color || '#007AFF'} />
+    </View>
+  );
+}

--- a/commons/components/spinner/styles.ts
+++ b/commons/components/spinner/styles.ts
@@ -1,0 +1,26 @@
+/**
+ * Spinner Styles
+ * Version: 1.0.0
+ * Created: 2025-01-11
+ */
+
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  fullScreenContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+    zIndex: 9999,
+  },
+});

--- a/commons/components/spinner/types.ts
+++ b/commons/components/spinner/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Spinner Types
+ * Version: 1.0.0
+ * Created: 2025-01-11
+ */
+
+export interface SpinnerProps {
+  /**
+   * 스피너 크기
+   * @default 'large'
+   */
+  size?: 'small' | 'large';
+
+  /**
+   * 스피너 색상
+   * @default '#007AFF'
+   */
+  color?: string;
+
+  /**
+   * 전체 화면 모드
+   * @default false
+   */
+  fullScreen?: boolean;
+}

--- a/components/map/components/map-view/hooks/useMapView.ts
+++ b/components/map/components/map-view/hooks/useMapView.ts
@@ -115,6 +115,7 @@ export function useMapView({
 
   const [mapCenterCoord, setMapCenterCoord] = useState<{ lat: number; lng: number } | null>(null);
   const [isWebViewReady, setIsWebViewReady] = useState(false);
+  const [isInitialLoadComplete, setIsInitialLoadComplete] = useState(false);
 
   const kakaoMapApiKey = useMemo(() => getKakaoMapApiKey(), []);
 
@@ -187,6 +188,29 @@ export function useMapView({
     });
   }, [resetZoom]);
 
+  // 초기 로딩 완료 처리 - 최대 3초 후 무조건 로딩 완료
+  useEffect(() => {
+    // 최대 대기 시간 (3초)
+    const maxWaitTimer = setTimeout(() => {
+      setIsInitialLoadComplete(true);
+    }, 3000);
+
+    // 모든 데이터가 준비되면 즉시 로딩 완료
+    if (isWebViewReady && !locationLoading && !capsulesLoading) {
+      const timer = setTimeout(() => {
+        setIsInitialLoadComplete(true);
+      }, WEBVIEW_MARKER_DELAY_MS);
+
+      return () => {
+        clearTimeout(timer);
+        clearTimeout(maxWaitTimer);
+      };
+    }
+
+    return () => clearTimeout(maxWaitTimer);
+  }, [isWebViewReady, locationLoading, capsulesLoading]);
+
+  // 마커 전송 (초기 로딩과 별개)
   useEffect(() => {
     if (locationLoading || capsulesLoading || capsuleMarkers.length === 0) return;
 
@@ -272,6 +296,7 @@ export function useMapView({
     handleMessage,
     handleMessageCommon,
     isWebViewReady,
+    isInitialLoadComplete,
     // 줌 제어
     scale,
     zoomLevel,

--- a/components/map/components/map-view/index.tsx
+++ b/components/map/components/map-view/index.tsx
@@ -12,6 +12,8 @@ import { useRef } from 'react';
 import { Platform, Text, View } from 'react-native';
 import WebView from 'react-native-webview';
 
+import { Spinner } from '@/commons/components/spinner';
+
 import CurrentLocation from '../current-location';
 import { CurrentLocationButton } from '../current-location-button';
 import { CurrentLocationMarker } from '../current-location-marker';
@@ -35,6 +37,7 @@ export default function MapView(props: MapViewProps = {}) {
     handleMessage,
     handleMessageCommon,
     isWebViewReady,
+    isInitialLoadComplete,
     scale,
     zoomLevel,
     handleZoomIn,
@@ -58,58 +61,71 @@ export default function MapView(props: MapViewProps = {}) {
         <View style={styles.errorContainer}>
           <Text style={styles.errorText}>카카오 API 키가 설정되지 않았습니다.</Text>
         </View>
-      ) : Platform.OS === 'web' ? (
-        <WebMapView
-          mapCenter={mapCenter}
-          level={zoomLevel}
-          markers={markersForWeb}
-          onMessage={handleMessageCommon}
-          currentLocation={location}
-          isLoadingLocation={locationLoading}
-          moveToLocationRef={moveToLocationRef}
-          scale={scale}
-        />
       ) : (
         <>
-          <WebView
-            ref={webViewRef}
-            source={{ html: htmlContent }}
-            style={styles.webview}
-            javaScriptEnabled={true}
-            domStorageEnabled={true}
-            originWhitelist={['*']}
-            onMessage={handleMessage}
-          />
-          <CurrentLocationMarker
-            webViewRef={webViewRef}
-            location={location}
-            isLoading={locationLoading}
-            isWebViewReady={isWebViewReady}
-          />
+          {/* 지도 UI 먼저 렌더링 (웹/앱 분기) */}
+          {Platform.OS === 'web' ? (
+            <WebMapView
+              mapCenter={mapCenter}
+              level={zoomLevel}
+              markers={markersForWeb}
+              onMessage={handleMessageCommon}
+              currentLocation={location}
+              isLoadingLocation={locationLoading}
+              moveToLocationRef={moveToLocationRef}
+              scale={scale}
+            />
+          ) : (
+            <>
+              <WebView
+                ref={webViewRef}
+                source={{ html: htmlContent }}
+                style={styles.webview}
+                javaScriptEnabled={true}
+                domStorageEnabled={true}
+                originWhitelist={['*']}
+                onMessage={handleMessage}
+              />
+              <CurrentLocationMarker
+                webViewRef={webViewRef}
+                location={location}
+                isLoading={locationLoading}
+                isWebViewReady={isWebViewReady}
+              />
+            </>
+          )}
+
+          {/* 로딩 중일 때 Spinner를 지도 위에 오버레이 */}
+          {!isInitialLoadComplete && <Spinner fullScreen />}
+
+          {/* 공통 UI 컴포넌트 - 로딩 완료 후 표시 */}
+          {isInitialLoadComplete && mapCenter && (
+            <View style={styles.currentLocationWrapper}>
+              <CurrentLocation lat={mapCenter.lat} lng={mapCenter.lng} />
+            </View>
+          )}
+          {isInitialLoadComplete && <EggSlot onPress={props.onEggSlotPress} />}
+          {/* 현재 위치로 이동 버튼 */}
+          {isInitialLoadComplete && (
+            <CurrentLocationButton
+              webViewRef={webViewRef}
+              location={location}
+              isLoading={locationLoading}
+              onMoveToLocation={Platform.OS === 'web' ? handleMoveToLocation : undefined}
+            />
+          )}
+          {/* 확대/축소 컨트롤 */}
+          {isInitialLoadComplete && (
+            <ZoomControl
+              onZoomIn={handleZoomIn}
+              onZoomOut={handleZoomOut}
+              onReset={resetZoom}
+              canZoomIn={scale < 3}
+              canZoomOut={scale > 0.5}
+            />
+          )}
         </>
       )}
-      {/* 공통 UI 컴포넌트 - web과 native 모두에서 사용 */}
-      {mapCenter && (
-        <View style={styles.currentLocationWrapper}>
-          <CurrentLocation lat={mapCenter.lat} lng={mapCenter.lng} />
-        </View>
-      )}
-      <EggSlot onPress={props.onEggSlotPress} />
-      {/* 현재 위치로 이동 버튼 */}
-      <CurrentLocationButton
-        webViewRef={webViewRef}
-        location={location}
-        isLoading={locationLoading}
-        onMoveToLocation={Platform.OS === 'web' ? handleMoveToLocation : undefined}
-      />
-      {/* 확대/축소 컨트롤 */}
-      <ZoomControl
-        onZoomIn={handleZoomIn}
-        onZoomOut={handleZoomOut}
-        onReset={resetZoom}
-        canZoomIn={scale < 3}
-        canZoomOut={scale > 0.5}
-      />
     </View>
   );
 }


### PR DESCRIPTION
## 📌 관련 이슈 (Task ID)

- ID: None

## 📝 작업 내용 (Details)

- Spinner 컴포넌트 생성 (commons/components/spinner)
- 지도 WebView 먼저 렌더링 후 스피너 오버레이 방식으로 변경
- 초기 로딩 완료 상태 관리 추가 (isInitialLoadComplete)
- 최대 3초 타임아웃으로 무한 로딩 방지
- 웹/앱 환경 모두 동일하게 작동하도록 구현