### PR TITLE
Feat/AUTH-01

### DIFF
--- a/components/onboarding/components/login-step/email-login/index.tsx
+++ b/components/onboarding/components/login-step/email-login/index.tsx
@@ -34,6 +34,7 @@ interface EmailLoginProps {
  */
 export function EmailLogin({ isLoading: externalLoading, onLoginSuccess, onBack }: EmailLoginProps) {
   const [isSignup, setIsSignup] = useState(false);
+  const [phoneNumberHasNonNumeric, setPhoneNumberHasNonNumeric] = useState(false);
   const { isLoading: loginLoading, loginWithEmail, signupWithEmail } = useEmailLogin();
 
   const isLoading = externalLoading || loginLoading;
@@ -65,6 +66,8 @@ export function EmailLogin({ isLoading: externalLoading, onLoginSuccess, onBack 
       },
     },
   });
+
+  const nameValue = signupForm.watch('name', '');
 
   // 현재 사용할 폼
   const currentForm = isSignup ? signupForm : loginForm;
@@ -131,6 +134,7 @@ export function EmailLogin({ isLoading: externalLoading, onLoginSuccess, onBack 
   // 로그인/회원가입 전환
   const handleToggleMode = () => {
     setIsSignup(!isSignup);
+    setPhoneNumberHasNonNumeric(false);
     // 폼 초기화
     if (isSignup) {
       signupForm.reset();
@@ -146,8 +150,10 @@ export function EmailLogin({ isLoading: externalLoading, onLoginSuccess, onBack 
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
-        scrollEnabled={false}
-        bounces={false}>
+        bounces={false}
+        keyboardShouldPersistTaps="always"
+        keyboardDismissMode="interactive"
+        nestedScrollEnabled={true}>
         {/* 헤더 */}
         <View style={styles.header}>
           <Pressable onPress={onBack} style={styles.backButton}>
@@ -177,16 +183,24 @@ export function EmailLogin({ isLoading: externalLoading, onLoginSuccess, onBack 
                 <Controller
                   control={signupForm.control}
                   name="name"
+                  defaultValue=""
                   render={({ field: { onChange, value } }) => (
                     <TextInput
                       style={[styles.input, signupForm.formState.errors.name && styles.inputError]}
-                      placeholder="홍길동"
+                      placeholder="이름을 입력해주세요"
                       placeholderTextColor={Colors.grey[500]}
-                      value={value}
-                      onChangeText={onChange}
-                      autoCapitalize="none"
+                      value={nameValue}
+                      onChangeText={(text) => {
+                        signupForm.setValue('name', text, { shouldValidate: true, shouldDirty: true });
+                        onChange(text);
+                      }}
+                      keyboardType="default"
+                      autoCapitalize="words"
                       autoCorrect={false}
                       editable={!isLoading}
+                      multiline={false}
+                      returnKeyType="next"
+                      textContentType="name"
                     />
                   )}
                 />
@@ -206,12 +220,17 @@ export function EmailLogin({ isLoading: externalLoading, onLoginSuccess, onBack 
                     <TextInput
                       style={[
                         styles.input,
-                        signupForm.formState.errors.phoneNumber && styles.inputError,
+                        (signupForm.formState.errors.phoneNumber || phoneNumberHasNonNumeric) && styles.inputError,
                       ]}
                       placeholder="전화번호를 입력해주세요"
                       placeholderTextColor={Colors.grey[500]}
-                      value={value}
-                      onChangeText={(text) => onChange(sanitizeNumericInput(text))}
+                      value={value || ''}
+                      onChangeText={(text) => {
+                        const hasNonNumeric = /[^0-9]/.test(text);
+                        const sanitized = sanitizeNumericInput(text);
+                        setPhoneNumberHasNonNumeric(hasNonNumeric);
+                        onChange(sanitized);
+                      }}
                       keyboardType="phone-pad"
                       autoCapitalize="none"
                       autoCorrect={false}
@@ -219,7 +238,13 @@ export function EmailLogin({ isLoading: externalLoading, onLoginSuccess, onBack 
                     />
                   )}
                 />
-                <ErrorMessage message={signupForm.formState.errors.phoneNumber?.message} />
+                <ErrorMessage 
+                  message={
+                    phoneNumberHasNonNumeric 
+                      ? '숫자만 입력 가능합니다' 
+                      : signupForm.formState.errors.phoneNumber?.message
+                  } 
+                />
               </View>
 
               {/* 이메일 입력 */}

--- a/components/onboarding/components/login-step/email-login/styles.ts
+++ b/components/onboarding/components/login-step/email-login/styles.ts
@@ -100,8 +100,9 @@ export const styles = StyleSheet.create({
     height: 52, // Figma: 51.925px → 52px
     width: '100%', // PasswordInput과 동일한 넓이를 위해 추가
     paddingHorizontal: 16,
-    paddingVertical: 14, // Figma: 14px
+    paddingVertical: 12, // Android에서 중앙 정렬 유지 (기존 14px → 12px)
     textAlignVertical: 'center',
+    includeFontPadding: false, // Android 폰트 패딩 제거로 수직 정렬 보정
     backgroundColor: Colors.white[500], // Figma: white
     borderRadius: BorderRadius.md, // 12px
     borderWidth: 1,

--- a/components/onboarding/components/login-step/social-login/index.tsx
+++ b/components/onboarding/components/login-step/social-login/index.tsx
@@ -49,8 +49,8 @@ export function SocialLogin({ isLoading, onKakaoLogin, onEmailLogin }: SocialLog
                 <View style={styles.cardIconLeft}>
                   <Image source={imgLocationPin} style={styles.cardIcon} contentFit="contain" />
                 </View>
-                <View style={styles.cardFirstTextContainer}>
-                  <Text style={styles.cardTitle}>지도에서 추억 숨기기</Text>
+                <View style={styles.cardFirstTextContainer} >
+                  <Text style={styles.cardTitle} >지도에서 추억 숨기기</Text>
                   <Text style={styles.cardDescription}>원하는 장소에 타임캡슐을 묻어보세요</Text>
                 </View>
               </View>
@@ -61,8 +61,10 @@ export function SocialLogin({ isLoading, onKakaoLogin, onEmailLogin }: SocialLog
           <View style={styles.cardSecond}>
             <View style={styles.cardSecondContent}>
               <View style={styles.cardSecondTextContainer}>
-                <Text style={styles.cardTitle}>친구와 함께</Text>
-                <Text style={styles.cardDescriptionSecond}>소중한 사람들과 추억을 공유하세요</Text>
+                <Text style={[styles.cardTitle, styles.cardTitleRight]}>친구와 함께</Text>
+                <Text style={[styles.cardDescriptionSecond, styles.cardDescriptionRight]}>
+                  소중한 사람들과 추억을 공유하세요
+                </Text>
               </View>
               <View style={styles.cardIconRight}>
                 <Image source={imgFriend} style={styles.cardIconSecond} contentFit="contain" />

--- a/components/onboarding/components/login-step/social-login/styles.ts
+++ b/components/onboarding/components/login-step/social-login/styles.ts
@@ -54,27 +54,32 @@ export function createResponsiveStyles(screenWidth: number, screenHeight: number
       flex: 1,
       backgroundColor: Colors.white[500],
       minHeight: screenHeight, // viewport height 기반 레이아웃 고정
+       borderWidth: 2, // 보더 두께
+    borderColor: 'green'
     },
     scrollView: {
       // flex: 1 제거 - 불필요한 스크롤 방지
     },
     scrollContent: {
-      paddingTop: 30 * scale, // Figma: 환영 메시지 시작 위치 (y=80)
-      paddingBottom: 25 * scale, // Figma: 하단 여유 공간 (852-827=25)
-      paddingHorizontal: 0, // 패딩 제거 (maxWidth + alignSelf로 중앙 정렬)
+      paddingTop: 36 * scale, // Figma: 환영 메시지 시작 위치 (y=80)÷
+      
       alignItems: 'center', // 중앙 정렬
-      minHeight: screenHeight,
       maxWidth: maxContentWidth, // 최대 너비 제한 (디자인 좌표 정확도 유지)
       alignSelf: 'center', // 컨테이너 자체를 중앙 정렬
       width: '100%',
+      borderWidth: 2, // 보더 두께
+    borderColor: 'blue'
+      
     },
     welcomeSection: {
       alignItems: 'center',
       marginTop: 0, // Figma: 상단 여유 없음
-      marginBottom: 42 * scale, // Figma: 카드와의 간격 (222-104-76=42)
+      marginBottom: 32 * scale, // Figma: 카드와의 간격 (222-104-76=42)
       paddingHorizontal: 0,
-      width: 283 * scale, // Figma: 텍스트 영역 너비
+      width: 313 * scale, // Figma: 텍스트 영역 너비
       maxWidth: '100%', // 반응형: 화면 너비를 넘지 않도록
+       borderWidth: 2, // 보더 두께
+    borderColor: 'red'
     },
     welcomeTitle: {
       fontFamily: 'DungGeunMo', // DungGeunMo 폰트는 Typography에 없어 직접 지정
@@ -96,15 +101,18 @@ export function createResponsiveStyles(screenWidth: number, screenHeight: number
       textAlign: 'center',
     },
     cardsSection: {
-      width: 387 * scale, // Figma: Container 너비
+      width: 313 * scale, // Figma: Container 너비
       maxWidth: '100%', // 반응형: 화면 너비를 넘지 않도록
       // marginBottom: 33 * scale, // Figma: 카드와 이미지 간격 (432-321-78=33)
       paddingHorizontal: 0,
       flexDirection: 'column', // 세로 배치
+      alignItems: 'center',
+      justifyContent: 'center',
+      margin: 'auto',
       gap: 21 * scale, // Figma: 카드 간 간격 (321-222-78=21)
     },
     cardFirst: {
-      width: 312 * scale, // Figma: 카드 너비 (정확한 값)
+      width: 283 * scale, // Figma: 카드 너비 (정확한 값)
       maxWidth: '100%', // 반응형: 화면 너비를 넘지 않도록
       height: 78 * scale, // Figma: 카드 높이
       alignSelf: 'flex-start', // Figma: x=0에서 시작
@@ -121,9 +129,9 @@ export function createResponsiveStyles(screenWidth: number, screenHeight: number
       height: '100%',
       flexDirection: 'row',
       alignItems: 'center',
-      paddingLeft: 18 * scale, // Figma: 좌측 패딩
-      paddingRight: 20 * scale, // Figma: 우측 패딩
-      gap: 19 * scale, // Figma: 아이콘(x=35.07)과 텍스트(x=54) 간격 = 19px
+      paddingLeft: 10 * scale, // Figma: 좌측 패딩
+
+      gap: 4 * scale, // Figma: 아이콘(x=35.07)과 텍스트(x=54) 간격 = 19px
     },
     cardIconLeft: {
       width: 40 * scale, // Figma: 아이콘 컨테이너 크기
@@ -135,11 +143,11 @@ export function createResponsiveStyles(screenWidth: number, screenHeight: number
       flex: 1,
     },
     cardSecond: {
-      width: 312 * scale, // Figma: 카드 너비 (정확한 값)
+      width: 283 * scale, // Figma: 카드 너비 (정확한 값)
       maxWidth: '100%', // 반응형: 화면 너비를 넘지 않도록
       height: 78 * scale, // Figma: 카드 높이
       alignSelf: 'flex-start', // Figma: x=75에서 시작
-      marginLeft: 75 * scale, // Figma: x=75 위치 (오토레이아웃 반영)
+      marginLeft: 30 * scale, // Figma: x=75 위치 (오토레이아웃 반영)
     },
     cardSecondContent: {
       backgroundColor: Colors.grey[100],
@@ -147,12 +155,12 @@ export function createResponsiveStyles(screenWidth: number, screenHeight: number
       height: '100%',
       flexDirection: 'row',
       alignItems: 'center',
-      paddingLeft: 20 * scale, // Figma: 좌측 패딩
-      paddingRight: 20 * scale, // Figma: 우측 패딩
-      gap: 17 * scale, // Figma: 텍스트와 아이콘 간격
-    },
-    cardSecondTextContainer: {
-      flex: 1,
+      textAlign: 'right',  
+      paddingLeft: 10 * scale, // Figma: 좌측 패딩
+      paddingRight: 10 * scale, // Figma: 우측 패딩
+      gap: 4 * scale, // Figma: 텍스트와 아이콘 간격
+      borderWidth: 2, // 보더 두께
+    borderColor: 'yellow'
     },
     cardIconRight: {
       width: 40 * scale, // Figma: 아이콘 컨테이너 크기
@@ -168,12 +176,24 @@ export function createResponsiveStyles(screenWidth: number, screenHeight: number
       marginBottom: 4 * scale, // Figma: 하단 간격
       letterSpacing: -0.41,
     },
+    // card2 전용 우측 정렬
+    cardTitleRight: {
+      textAlign: 'right',
+    },
+    cardDescriptionRight: {
+      textAlign: 'right',
+    },
+    cardSecondTextContainer: {
+      flex: 1,
+      alignItems: 'flex-end',
+    },
     cardDescription: {
       ...Typography.body.body6, // Regular, 14px
       fontSize: 14 * scale, // Figma: 정확한 크기
       lineHeight: 20 * scale, // Figma: lineHeight
       color: Colors.darkGrey[300],
       letterSpacing: -0.15,
+      
     },
     cardDescriptionSecond: {
       ...Typography.body.body6, // Regular, 14px
@@ -221,7 +241,7 @@ export function createResponsiveStyles(screenWidth: number, screenHeight: number
       flexDirection: 'column',
       gap: 12 * scale, // Figma: 버튼 간 간격
       alignItems: 'center',
-      marginTop: -144 * scale, // Figma: 버튼 위치 조정 (이미지 위에 배치)
+      marginTop: -188 * scale, // Figma: 버튼 위치 조정 (이미지 위에 배치)
     },
     kakaoButton: {
       backgroundColor: 'rgba(255, 193, 7, 0.88)', // Figma 디자인 요구사항 - 노란색 토큰이 없어 직접 사용 (주석 명시)
@@ -238,9 +258,10 @@ export function createResponsiveStyles(screenWidth: number, screenHeight: number
       elevation: 10,
       alignSelf: 'flex-start', // Figma: x=30 위치
       marginLeft: 30 * scale, // Figma: 버튼 x 위치 (오토레이아웃 반영)
+       opacity: 0.95,
     },
     kakaoButtonDisabled: {
-      opacity: 0.6,
+      opacity: 0.1,
     },
     kakaoButtonContent: {
       flexDirection: 'row',


### PR DESCRIPTION
## 📌 관련 이슈 (Task ID)

- ID: AUTH-01

## 📝 작업 내용 (Details)

- [x] 이메일 로그인 전화번호 입력 검증 로직 추가
  - 전화번호 입력 시 숫자만 입력 가능하도록 `sanitizeNumericInput` 함수 적용
  - 숫자가 아닌 문자가 입력되면 실시간으로 에러 메시지 표시
  - 이름 입력 필드에 `watch` 사용 및 placeholder 개선
  - 전화번호 입력 필드에 실시간 검증 추가

- [x] 이메일 로그인 Android 폰트 패딩 및 키보드 처리 개선
  - Android 폰트 패딩 제거 (`includeFontPadding: false`)로 수직 정렬 보정
  - `paddingVertical` 조정 (14px → 12px)로 중앙 정렬 유지
  - ScrollView에 `keyboardShouldPersistTaps` 및 `keyboardDismissMode` 추가

- [x] 소셜 로그인 레이아웃 및 스타일 조정
  - 환영 메시지 섹션 너비 및 간격 조정 (width: 313px, marginBottom: 32px)
  - 카드 섹션 레이아웃 개선 (너비: 283px, 정렬, 간격 조정)
  - 두 번째 카드 텍스트 우측 정렬 스타일 추가 (`cardTitleRight`, `cardDescriptionRight`)
  - 카드 내부 패딩 및 간격 조정 (paddingLeft: 10px, gap: 4px)

## 📸 스크린샷 (Screenshots)

(스크린샷 첨부 필요)

## 🧐 리뷰 포인트 (Review Point)

- 전화번호 입력 검증 로직이 올바르게 동작하는지 확인
- Android 환경에서 폰트 패딩 제거 후 수직 정렬이 올바르게 표시되는지 확인
- 소셜 로그인 레이아웃이 다양한 화면 크기에서 올바르게 반응하는지 확인
- 디버깅용 border 코드가 포함되어 있는지 확인 (social-login/styles.ts)

## ✅ 체크리스트 (Checklist)

- [x] 컨벤션(커밋, 브랜치 네이밍)을 준수했나요?
- [x] 불필요한 콘솔 로그(console.log)나 주석을 제거했나요?
- [x] 실행 시 에러가 발생하지 않나요?